### PR TITLE
Fix metamask depreciation

### DIFF
--- a/ui/core/src/api/utils/getWeb3.ts
+++ b/ui/core/src/api/utils/getWeb3.ts
@@ -2,7 +2,9 @@ import detectMetaMaskProvider from "@metamask/detect-provider";
 import { AbstractProvider } from "web3-core";
 import Web3 from "web3";
 
-type MetaMaskProvider = AbstractProvider & { enable: () => Promise<void> };
+type MetaMaskProvider = AbstractProvider & {
+  request: (a: any) => Promise<void>;
+};
 type OldMetaMaskProvider = AbstractProvider & {
   currentProvider: AbstractProvider;
 };
@@ -20,7 +22,12 @@ export const getWeb3: Web3Getter = async () => {
   if (!mmp || !win) return null;
   if (win.ethereum) {
     const web3 = new Web3(win.ethereum);
-    await win.ethereum.enable();
+    try {
+      await win.ethereum.request({ method: "eth_requestAccounts" });
+    } catch (err) {
+      console.log(err);
+      return null;
+    }
     return web3;
   }
 


### PR DESCRIPTION
When we are connecting to metamask we have used a non-standard method which has been deprecated. This upgrades to use the latest API. 