### PR TITLE
remove the generate bin step since all solidity bin file checked in

### DIFF
--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-mac install ethereum
+brew install ethereum
 cd testnet-contracts
 yarn
 # ebrelayer generate

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -2,5 +2,5 @@
 mac install ethereum
 cd testnet-contracts
 yarn
-ebrelayer generate
+# ebrelayer generate
 cp .env.example .env


### PR DESCRIPTION
Some tester get all kinds of error when run init scripts to generate bin files. comment the step out and use the bin file already checked in. Will add it back, reference issue 1.