### PR TITLE
use https instead ssh://

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
 2. Clone the repository:
 
 ```
-git clone ssh://git@github.com/Sifchain/sifnode && cd sifnode
+git clone https://github.com/Sifchain/sifnode.git && cd sifnode
 ```
 
 3. Checkout the latest testnet release:


### PR DESCRIPTION
Testnet participants do not have appropriate access to clone via ssh - use https instead
```
git clone ssh://git@github.com/Sifchain/sifnode
Cloning into 'sifnode'...
The authenticity of host 'github.com (140.82.121.3)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.121.3' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```