### PR TITLE
Update readme.md replace symbol

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,11 +126,11 @@ sifnodecli tx staking create-validator \
     --commission-rate 0.1 \
     --amount 1000000000rowan \
     --pubkey $(sifnoded tendermint show-validator) \
-    --moniker <moniker> \
+    --moniker "moniker" \
     --chain-id monkey-bars \
     --min-self-delegation 1 \
     --gas auto \
-    --from <moniker> \
+    --from "moniker" \
     --keyring-backend file
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 
 - [Ruby 2.6.x](https://www.ruby-lang.org/en/documentation/installation)
 - [Golang](https://golang.org/doc/install)
+- [Node.js >=12.19.0](https://nodejs.org/en/)
 
 ## Getting started
 


### PR DESCRIPTION
When configured from:
https://github.com/Sifchain/sifnode/blob/develop/readme.md
In the line: --moniker < moniker > \\
it is necessary to replace the <> symbol with ""
because otherwise it fails (hosted OS - Ubuntu 20.04)