### PR TITLE
[ChainOps] EBS CSI plugin and StorageClass in Terraform

### DIFF
--- a/build/helm/sifnode/templates/storageclass.yaml
+++ b/build/helm/sifnode/templates/storageclass.yaml
@@ -1,5 +1,0 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: {{ .Values.pvc.storageclass }}
-provisioner: efs.csi.aws.com

--- a/build/terraform/providers/aws/variables.tf
+++ b/build/terraform/providers/aws/variables.tf
@@ -88,6 +88,11 @@ variable "efs_pv_storageclass" {
   default     = "efs-sc"
 }
 
+variable "ebs_pv_storageclass" {
+  description = "The name of the storageclass for the EBS driver"
+  default     = "ebs-sc"
+}
+
 variable "efs_pv_capacity" {
   description = "EFS storage capacity"
   default     = "5Gi"


### PR DESCRIPTION
- Previously I replaced EBS with EFS type of storage but we still need EBS for the single pods to save data on Persistent Storage.
- I also moved the StorageClass-es deployment to be part of the Terraform setup.