### PR TITLE
deploy/scripts/entrypoint.sh: rest-server --unsafe-cors

### DIFF
--- a/deploy/scripts/entrypoint.sh
+++ b/deploy/scripts/entrypoint.sh
@@ -14,7 +14,7 @@ start_daemon() {
 # Rest server.
 #
 start_rest_server() {
-  sifnodecli rest-server --laddr tcp://0.0.0.0:1317 &
+  sifnodecli rest-server --laddr tcp://0.0.0.0:1317 --unsafe-cors &
 }
 
 #


### PR DESCRIPTION
Wasn't sure if change should be in `deploy/helm/sifnode/templates/sifnodecli-deployment.yaml`

Resolves https://github.com/Sifchain/sifnode/issues/298