### PR TITLE
[Frontend] Peggy

### DIFF
--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -22,6 +22,7 @@
     "bip39": "^3.0.2",
     "coingecko-api": "^1.0.10",
     "decimal.js-light": "^2.5.1",
+    "eventemitter2": "^6.4.3",
     "ganache-time-traveler": "^1.0.15",
     "jsbi": "^3.1.4",
     "reconnecting-websocket": "^4.4.0",

--- a/ui/core/src/api/PeggyService/IPeggyService.ts
+++ b/ui/core/src/api/PeggyService/IPeggyService.ts
@@ -1,0 +1,18 @@
+import { AssetAmount } from "../../entities";
+import { TxEventEmitter } from "./types";
+
+export type IPeggyService = {
+  /**
+   * Release funds from the Ethereum Smart Contract and burn the equivalent tokens in sifnode
+   * @param ethereumRecipient Ethereum address to send funds to
+   * @param assetAmount amount of funds and sif asset eg ceth
+   */
+  burn(ethereumRecipient: string, assetAmount: AssetAmount): TxEventEmitter;
+
+  /**
+   * Lock funds in the Ethereum Smart Contract and mint the equivalent tokens in sifnode
+   * @param cosmosRecipient sif address to send funds to
+   * @param assetAmount amount of funds and eth asset eg erowan
+   */
+  lock(cosmosRecipient: string, assetAmount: AssetAmount): TxEventEmitter;
+};

--- a/ui/core/src/api/PeggyService/PeggyService.test.ts
+++ b/ui/core/src/api/PeggyService/PeggyService.test.ts
@@ -28,4 +28,51 @@ describe("PeggyService", () => {
       "Complete",
     ]);
   });
+
+  test("error", async () => {
+    const events: any[] = [];
+    const service = create();
+
+    expect(events).toEqual([]);
+
+    await new Promise<void>((resolve) => {
+      service
+        .lock("sif12345876512341234", AssetAmount(ATK, "100"))
+        .onError((e) => {
+          events.push(e);
+          resolve();
+        });
+    });
+
+    expect(events).toEqual([
+      {
+        txHash: "abcd1234", // temp
+        type: "Error",
+        payload: "Boom!",
+      },
+    ]);
+  });
+
+  test("burn", async () => {
+    const events: any[] = [];
+    const service = create();
+
+    expect(events).toEqual([]);
+
+    await new Promise<void>((resolve) => {
+      service
+        .burn("sif12345876512341234", AssetAmount(ATK, "10000"))
+        .onTxEvent((e) => events.push(e))
+        .onComplete(() => resolve());
+    });
+
+    expect(events.map((e) => e.type)).toEqual([
+      "SifTxInitiated",
+      ...Array.from(Array(30).keys()).map(() => "SifConfCountChanged"),
+      "SifTxConfirmed",
+      "EthTxInitiated",
+      "EthTxConfirmed",
+      "Complete",
+    ]);
+  });
 });

--- a/ui/core/src/api/PeggyService/PeggyService.test.ts
+++ b/ui/core/src/api/PeggyService/PeggyService.test.ts
@@ -1,0 +1,31 @@
+import { ATK } from "../../constants";
+import { AssetAmount } from "../../entities";
+import create from "./PeggyService";
+describe("PeggyService", () => {
+  // We are going to test this as a mock implementation
+  // These tests may have to change to be integration tests
+  // at a later point
+
+  test("lock", async () => {
+    const events: any[] = [];
+    const service = create();
+
+    expect(events).toEqual([]);
+
+    await new Promise<void>((resolve) => {
+      service
+        .lock("sif12345876512341234", AssetAmount(ATK, "10000"))
+        .onTxEvent((e) => events.push(e))
+        .onComplete(() => resolve());
+    });
+
+    expect(events.map((e) => e.type)).toEqual([
+      "EthTxInitiated",
+      ...Array.from(Array(30).keys()).map(() => "EthConfCountChanged"),
+      "EthTxConfirmed",
+      "SifTxInitiated",
+      "SifTxConfirmed",
+      "Complete",
+    ]);
+  });
+});

--- a/ui/core/src/api/PeggyService/PeggyService.ts
+++ b/ui/core/src/api/PeggyService/PeggyService.ts
@@ -56,6 +56,13 @@ export default function createPeggyService(): IPeggyService {
       const txHash = "abcd1234";
       // Create an emitter
       const e = createTxEventEmitter(txHash);
+
+      // add chaos
+      if (assetAmount.equalTo("100")) {
+        setTimeout(() => {
+          e.emit({ txHash, type: "Error", payload: "Boom!" });
+        }, 345);
+      }
       // Direct that emitter through a mock sequence
       return mockLockSequence(e);
     },

--- a/ui/core/src/api/PeggyService/PeggyService.ts
+++ b/ui/core/src/api/PeggyService/PeggyService.ts
@@ -1,0 +1,63 @@
+import { AssetAmount } from "../../entities";
+import { IPeggyService } from "./IPeggyService";
+import { createTxEventEmitter } from "./TxEventEmitter";
+import { TxEventEmitter } from "./types";
+
+// MOCK SEQUENCES
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+function mockLockSequence(emitter: TxEventEmitter) {
+  (async () => {
+    await sleep(20);
+    emitter.emit({ type: "EthTxInitiated", payload: {} });
+    for (let count of Array.from(Array(30).keys())) {
+      await sleep(10);
+      emitter.emit({ type: "EthConfCountChanged", payload: count });
+    }
+    emitter.emit({ type: "EthTxConfirmed", payload: {} });
+    await sleep(20);
+    emitter.emit({ type: "SifTxInitiated", payload: {} });
+    await sleep(50);
+    emitter.emit({ type: "SifTxConfirmed", payload: {} });
+    emitter.emit({ type: "Complete", payload: {} });
+  })();
+  return emitter;
+}
+
+function mockBurnSequence(emitter: TxEventEmitter) {
+  (async () => {
+    await sleep(20);
+    emitter.emit({ type: "SifTxInitiated", payload: {} });
+    for (let count of Array.from(Array(30).keys())) {
+      await sleep(10);
+      emitter.emit({ type: "SifConfCountChanged", payload: count });
+    }
+    emitter.emit({ type: "SifTxConfirmed", payload: {} });
+    await sleep(20);
+    emitter.emit({ type: "EthTxInitiated", payload: {} });
+    await sleep(50);
+    emitter.emit({ type: "EthTxConfirmed", payload: {} });
+    emitter.emit({ type: "Complete", payload: {} });
+  })();
+  return emitter;
+}
+
+export default function createPeggyService(): IPeggyService {
+  return {
+    burn(ethereumRecipient: string, assetAmount: AssetAmount) {
+      // Some random string for now
+      const txHash = "abcd1234";
+      // Create an emitter
+      const e = createTxEventEmitter(txHash);
+      // Direct that emitter through a mock sequence
+      return mockBurnSequence(e);
+    },
+    lock(cosmosRecipient: string, assetAmount: AssetAmount) {
+      // Some random string for now
+      const txHash = "abcd1234";
+      // Create an emitter
+      const e = createTxEventEmitter(txHash);
+      // Direct that emitter through a mock sequence
+      return mockLockSequence(e);
+    },
+  };
+}

--- a/ui/core/src/api/PeggyService/TxEventEmitter.ts
+++ b/ui/core/src/api/PeggyService/TxEventEmitter.ts
@@ -39,6 +39,10 @@ export function createTxEventEmitter(txHash: string) {
       emitter.on("Complete", handler);
       return instance;
     },
+    onError(handler) {
+      emitter.on("Error", handler);
+      return instance;
+    },
   };
   return instance;
 }

--- a/ui/core/src/api/PeggyService/TxEventEmitter.ts
+++ b/ui/core/src/api/PeggyService/TxEventEmitter.ts
@@ -1,0 +1,44 @@
+import { TxEventEmitter, TxEventPrepopulated } from "./types";
+import { EventEmitter2 } from "eventemitter2";
+/**
+ * Adds types around EventEmitter2
+ * @param txHash transaction hash this emitter responds to
+ */
+export function createTxEventEmitter(txHash: string) {
+  const emitter = new EventEmitter2();
+  const instance: TxEventEmitter = {
+    emit(e: TxEventPrepopulated) {
+      emitter.emit(e.type, { ...e, txHash: e.txHash || txHash });
+    },
+    onTxEvent(handler) {
+      emitter.onAny((e, v) => handler(v));
+      return instance;
+    },
+    onEthConfCountChanged(handler) {
+      emitter.on("EthConfCountChanged", handler);
+      return instance;
+    },
+    onEthTxConfirmed(handler) {
+      emitter.on("EthTxConfirmed", handler);
+      return instance;
+    },
+
+    onSifTxConfirmed(handler) {
+      emitter.on("SifTxConfirmed", handler);
+      return instance;
+    },
+    onEthTxInitiated(handler) {
+      emitter.on("EthTxInitiated", handler);
+      return instance;
+    },
+    onSifTxInitiated(handler) {
+      emitter.on("SifTxInitiated", handler);
+      return instance;
+    },
+    onComplete(handler) {
+      emitter.on("Complete", handler);
+      return instance;
+    },
+  };
+  return instance;
+}

--- a/ui/core/src/api/PeggyService/index.ts
+++ b/ui/core/src/api/PeggyService/index.ts
@@ -1,0 +1,1 @@
+export * from "./PeggyService";

--- a/ui/core/src/api/PeggyService/peggy-plan.md
+++ b/ui/core/src/api/PeggyService/peggy-plan.md
@@ -1,0 +1,41 @@
+Note
+
+We need to sketch out how we are going to get these events
+
+# 1. lock eth in ethereum then mint ceth in sifchain
+
+1.  TxEventEthTxInitiated `{ originTxHash: xxx, destAddress: xxx, amount: n }`
+2.  TxEventEthConfCountChanged `{ originTxHash: xxx, count: n }`
+3.  TxEventEthTxConfirmed `{ originTxHash: xxx }`
+4.  TxEventSifTxInitiated `{ originTxHash: xxx, destAddress: xxx, destTxHash: xxx, amount: n }` (_optional_)
+5.  TxEventSifConfCountChanged `{ originTxHash: xxx, count: n }` (_optional_)
+6.  TxEventSifTxConfirmed `{ originTxHash: xxx, destAddress: xxx, destTxHash: xxx, amount: n }`
+
+# 2. burn ceth in sifchain then eth back to ethereum
+
+1.  TxEventEthTxInitiated `{ originTxHash: xxx, destAddress: xxx, amount: n, ... }`
+2.  TxEventEthConfCountChanged `{ originTxHash: xxx, count: n }`
+3.  TxEventEthTxConfirmed `{ originTxHash: xxx }`
+4.  TxEventSifTxInitiated `{ originTxHash: xxx, destAddress: xxx, destTxHash: xxx, amount: n }` (_optional_)
+5.  TxEventSifConfCountChanged `{ originTxHash: xxx, count: n }` (_optional_)
+6.  TxEventSifTxConfirmed `{ originTxHash: xxx, destAddress: xxx, destTxHash: xxx, amount: n }`
+
+# 3. lock rowan in sifchain transfer to ethereum
+
+# 4. burn erowan in ethereum then transfer rowan back to sifchain
+
+### TxEventEthTxInitiated
+
+### TxEventEthConfCountChanged
+
+### TxEventSifConfCountChanged
+
+### TxEventEthTxConfirmed
+
+### TxEventSifTxInitiated
+
+### TxEventSifTxConfirmed
+
+### TxEventError;
+
+### TxEventComplete;

--- a/ui/core/src/api/PeggyService/types.ts
+++ b/ui/core/src/api/PeggyService/types.ts
@@ -1,0 +1,64 @@
+type TxEventBase<T> = {
+  txHash: string;
+  payload: T;
+};
+
+export type TxEventEthConfCountChanged = {
+  type: "EthConfCountChanged";
+} & TxEventBase<number>;
+
+export type TxEventSifConfCountChanged = {
+  type: "SifConfCountChanged";
+} & TxEventBase<number>;
+
+export type TxEventEthTxInitiated = {
+  type: "EthTxInitiated";
+} & TxEventBase<any>;
+
+export type TxEventEthTxConfirmed = {
+  type: "EthTxConfirmed";
+} & TxEventBase<any>;
+
+export type TxEventSifTxInitiated = {
+  type: "SifTxInitiated";
+} & TxEventBase<any>;
+
+export type TxEventSifTxConfirmed = {
+  type: "SifTxConfirmed";
+} & TxEventBase<any>;
+
+export type TxEventComplete = {
+  type: "Complete";
+} & TxEventBase<any>;
+
+export type TxEvent =
+  | TxEventEthConfCountChanged
+  | TxEventSifConfCountChanged
+  | TxEventEthTxInitiated
+  | TxEventEthTxConfirmed
+  | TxEventSifTxInitiated
+  | TxEventSifTxConfirmed
+  | TxEventComplete;
+
+export type TxEventPrepopulated = Omit<TxEvent, "txHash"> & { txHash?: string };
+
+export type TxEventEmitter = {
+  emit: (e: TxEventPrepopulated) => void;
+  onTxEvent: (handler: (e: TxEvent) => void) => TxEventEmitter;
+  onEthConfCountChanged: (
+    handler: (e: TxEventEthConfCountChanged) => void
+  ) => TxEventEmitter;
+  onEthTxInitiated: (
+    handler: (e: TxEventEthTxInitiated) => void
+  ) => TxEventEmitter;
+  onEthTxConfirmed: (
+    handler: (e: TxEventEthTxConfirmed) => void
+  ) => TxEventEmitter;
+  onSifTxInitiated: (
+    handler: (e: TxEventSifTxInitiated) => void
+  ) => TxEventEmitter;
+  onSifTxConfirmed: (
+    handler: (e: TxEventSifTxConfirmed) => void
+  ) => TxEventEmitter;
+  onComplete: (handler: (e: TxEventComplete) => void) => TxEventEmitter;
+};

--- a/ui/core/src/api/PeggyService/types.ts
+++ b/ui/core/src/api/PeggyService/types.ts
@@ -13,23 +13,27 @@ export type TxEventSifConfCountChanged = {
 
 export type TxEventEthTxInitiated = {
   type: "EthTxInitiated";
-} & TxEventBase<any>;
+} & TxEventBase<unknown>;
 
 export type TxEventEthTxConfirmed = {
   type: "EthTxConfirmed";
-} & TxEventBase<any>;
+} & TxEventBase<unknown>;
 
 export type TxEventSifTxInitiated = {
   type: "SifTxInitiated";
-} & TxEventBase<any>;
+} & TxEventBase<unknown>;
 
 export type TxEventSifTxConfirmed = {
   type: "SifTxConfirmed";
-} & TxEventBase<any>;
+} & TxEventBase<unknown>;
 
 export type TxEventComplete = {
   type: "Complete";
-} & TxEventBase<any>;
+} & TxEventBase<unknown>;
+
+export type TxEventError = {
+  type: "Error";
+} & TxEventBase<unknown>;
 
 export type TxEvent =
   | TxEventEthConfCountChanged
@@ -38,6 +42,7 @@ export type TxEvent =
   | TxEventEthTxConfirmed
   | TxEventSifTxInitiated
   | TxEventSifTxConfirmed
+  | TxEventError
   | TxEventComplete;
 
 export type TxEventPrepopulated = Omit<TxEvent, "txHash"> & { txHash?: string };
@@ -61,4 +66,5 @@ export type TxEventEmitter = {
     handler: (e: TxEventSifTxConfirmed) => void
   ) => TxEventEmitter;
   onComplete: (handler: (e: TxEventComplete) => void) => TxEventEmitter;
+  onError: (handler: (e: TxEventError) => void) => TxEventEmitter;
 };

--- a/ui/core/src/constants/tokens.ts
+++ b/ui/core/src/constants/tokens.ts
@@ -14,6 +14,14 @@ export const ROWAN = Coin({
   network: Network.SIFCHAIN,
 });
 
+export const ATK = Token({
+  symbol: "atk",
+  address: "0xbaAA2a3237035A2c7fA2A33c76B44a8C6Fe18e87",
+  decimals: 18,
+  name: "atk",
+  network: Network.ETHEREUM,
+});
+
 export const CATK = Coin({
   symbol: "catk",
   decimals: 18,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6955,6 +6955,11 @@ event-pubsub@4.3.0:
   resolved "https://registry.yarnpkg.com/event-pubsub/-/event-pubsub-4.3.0.tgz#f68d816bc29f1ec02c539dc58c8dd40ce72cb36e"
   integrity sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==
 
+eventemitter2@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.3.tgz#35c563619b13f3681e7eb05cbdaf50f56ba58820"
+  integrity sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==
+
 eventemitter3@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"


### PR DESCRIPTION
We need a mock peggy interface to move forward with peggy on the frontend which we sort out the details of the interaction.

Sofar this defines a set of events:

```
TxEventEthConfCountChanged
TxEventSifConfCountChanged
TxEventEthTxInitiated
TxEventEthTxConfirmed
TxEventSifTxInitiated
TxEventSifTxConfirmed
TxEventError;
TxEventComplete;
```

These events will be pulled from various sources from a combination of listening to the ethereum blockchain, the ebrelayer and sifnode.

This will be complex so it is best to place this complexity behind an abstraction. 

![peggy-structure-2](https://user-images.githubusercontent.com/1256409/101964603-0b5e6b00-3c66-11eb-8906-6fa13d2850cb.png)

This PR is an attempt defines the interface that the TxEventEmitter uses so we can start to use it to connect to our Vue app while the other peggy stuff is still being worked on.

What are thoughts on: 
* Fluent interface? Could pass a config object with all handlers attached - doesn't seem as flexible to me
* Hard coding event types as API vs types? - Reason I was thinking to do it this way was because we get better typesafety but we could use event names as string literal union types that might mean less code but less clear intent
.

