### PR TITLE
[ChainOps] Terraform tweaks.

### DIFF
--- a/deploy/terraform/providers/aws/variables.tf
+++ b/deploy/terraform/providers/aws/variables.tf
@@ -46,7 +46,7 @@ variable "min_capacity" {
 }
 
 variable "instance_type" {
-  default = "t2.medium"
+  default = "t2.xlarge"
 }
 
 variable "ami_type" {


### PR DESCRIPTION
Increase the default k8s compute instance from t2.medium to t2.xlarge.