### PR TITLE
[Frontend] Fix swap not working because pools not loading

### DIFF
--- a/ui/core/src/actions/clp/index.ts
+++ b/ui/core/src/actions/clp/index.ts
@@ -9,8 +9,8 @@ export default ({
 }: ActionContext<"SifService" | "ClpService", "pools" | "wallet">) => {
   const state = api.SifService.getState();
 
-  // Sync MarketService with pool store
-  api.ClpService.onPoolsUpdated((pools) => {
+  async function syncPools() {
+    const pools = await api.ClpService.getPools();
     for (let pool of pools) {
       store.pools[pool.symbol()] = pool;
     }
@@ -21,9 +21,14 @@ export default ({
         detail: "Create liquidity pool to swap.",
       });
     }
-  });
+  }
 
-  api.ClpService.onWSError(({ sifWsUrl }) => {
+  syncPools();
+
+  // Sync MarketService with pool store
+  api.SifService.onTx(syncPools);
+
+  api.SifService.onSocketError(({ sifWsUrl }) => {
     notify({
       type: "error",
       message: "Websocket Not Connected",

--- a/ui/core/src/actions/clp/index.ts
+++ b/ui/core/src/actions/clp/index.ts
@@ -23,9 +23,10 @@ export default ({
     }
   }
 
+  // Sync on load
   syncPools();
 
-  // Sync MarketService with pool store
+  // Then every transaction
   api.SifService.onTx(syncPools);
 
   api.SifService.onSocketError(({ sifWsUrl }) => {

--- a/ui/core/src/api/SifService/SifService.ts
+++ b/ui/core/src/api/SifService/SifService.ts
@@ -26,9 +26,11 @@ export type SifServiceContext = {
   sifWsUrl: string;
   assets: Asset[];
 };
-
+type HandlerFn<T> = (a: T) => void;
 export type ISifService = IWalletService & {
   getSupportedTokens: () => Asset[];
+  onSocketError: (handler: HandlerFn<any>) => void;
+  onTx: (handler: HandlerFn<any>) => void;
 };
 
 /**
@@ -125,6 +127,14 @@ export default function createSifService({
 
     isConnected() {
       return state.connected;
+    },
+
+    onSocketError(handler: HandlerFn<any>) {
+      client?.getUnsignedClient().onSocketError(handler);
+    },
+
+    onTx(handler: HandlerFn<any>) {
+      client?.getUnsignedClient().onTx(handler);
     },
 
     async setPhrase(mnemonic: Mnemonic): Promise<Address> {


### PR DESCRIPTION
There was a bug in the peg UI after the refactor to share a socket connection. Forgot to run the pool sync on initialize. 

This does it properly in app/clp using event hooks exposed by SifService which should manage the main relationship to sifchain.

Lesson: we should prioritise cypress testing as soon as we can to avoid this sort of stuff.