### PR TITLE
[Frontend] Only send notification once pools object changes

### DIFF
--- a/ui/core/src/actions/clp/index.ts
+++ b/ui/core/src/actions/clp/index.ts
@@ -43,18 +43,18 @@ export default ({
     }
   }
 
-  effect(() => {
-    if (Object.keys(store.pools).length === 0) {
-      notify({
-        type: "error",
-        message: "No Liquidity Pools Found",
-        detail: "Create liquidity pool to swap.",
-      });
-    }
-  });
-
   // Sync on load
-  syncPools();
+  syncPools().then(() => {
+    effect(() => {
+      if (Object.keys(store.pools).length === 0) {
+        notify({
+          type: "error",
+          message: "No Liquidity Pools Found",
+          detail: "Create liquidity pool to swap.",
+        });
+      }
+    });
+  });
 
   // Then every transaction
 

--- a/ui/core/src/actions/clp/index.ts
+++ b/ui/core/src/actions/clp/index.ts
@@ -3,6 +3,7 @@ import { ActionContext } from "..";
 import { PoolStore } from "../../store/pools";
 import notify from "../../api/utils/Notifications";
 import { toPool } from "../../api/utils/SifClient/toPool";
+import { effect } from "@vue/reactivity";
 
 export default ({
   api,
@@ -40,15 +41,17 @@ export default ({
       }
       store.accountpools = accountPools;
     }
+  }
 
-    if (pools.length === 0) {
+  effect(() => {
+    if (Object.keys(store.pools).length === 0) {
       notify({
         type: "error",
         message: "No Liquidity Pools Found",
         detail: "Create liquidity pool to swap.",
       });
     }
-  }
+  });
 
   // Sync on load
   syncPools();


### PR DESCRIPTION
This stops this thing for liquidity pools:

![image](https://user-images.githubusercontent.com/1256409/104256293-13acfe80-54cf-11eb-9cdc-bb390419c502.png)
