### PR TITLE
[ChainOps] Sifgen hotfix.

### DIFF
--- a/cmd/sifgen/main.go
+++ b/cmd/sifgen/main.go
@@ -116,7 +116,7 @@ func nodeCreateCmd() *cobra.Command {
 
 			if standalone {
 				node.Standalone = true
-				node.AdminCLPAddresses = strings.Split(adminCLPAddresses, ",")
+				node.AdminCLPAddresses = strings.Split(adminCLPAddresses, "|")
 				node.AdminOracleAddress = adminOracleAddress
 				node.IPAddr = bindIPAddress
 				node.BondAmount = bondAmount

--- a/tools/sifgen/common/types/genesis.go
+++ b/tools/sifgen/common/types/genesis.go
@@ -141,10 +141,10 @@ type CLPParams struct {
 }
 
 type CLP struct {
-	Params                    CLPParams   `json:"params"`
-	WhiteListValidatorAddress interface{} `json:"white_list_validator_address"`
-	PoolList                  interface{} `json:"pool_list"`
-	LiquidityProviderList     interface{} `json:"liquidity_provider_list"`
+	Params                CLPParams   `json:"params"`
+	AddressWhitelist      interface{} `json:"address_whitelist"`
+	PoolList              interface{} `json:"pool_list"`
+	LiquidityProviderList interface{} `json:"liquidity_provider_list"`
 }
 
 type Faucet struct {


### PR DESCRIPTION
Was using the wrong field name for the CLP admin addresses.