### PR TITLE
fix wrong sequence number.

### DIFF
--- a/cmd/ebrelayer/relayer/ethereum.go
+++ b/cmd/ebrelayer/relayer/ethereum.go
@@ -200,6 +200,8 @@ func (sub EthereumSub) Start(completionEvent *sync.WaitGroup) {
 					events := sub.EventsBuffer.GetHeaderEvents()
 					for _, event := range events {
 						err := sub.handleEthereumEvent(event)
+						// Sleep 3 seconds before send next transaction to cosmos, guarantee correct sequence number
+						time.Sleep(3 * time.Second)
 
 						if err != nil {
 							sub.Logger.Error(err.Error())


### PR DESCRIPTION
If relayer continuously send the multiple transactions to cosmos, we get a wrong sequence number error. add three seconds sleep to make sure last transaction processed before sending next one.