### PR TITLE
Use correct encoding type for ebrelayer

### DIFF
--- a/x/ethbridge/types/msgs.go
+++ b/x/ethbridge/types/msgs.go
@@ -214,11 +214,7 @@ func (msg MsgCreateEthBridgeClaim) ValidateBasic() error {
 
 // GetSignBytes encodes the message for signing
 func (msg MsgCreateEthBridgeClaim) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
-	if err != nil {
-		panic(err)
-	}
-	return sdk.MustSortJSON(b)
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
 }
 
 // GetSigners defines whose signature is required
@@ -263,12 +259,7 @@ func (msg MsgUpdateWhiteListValidator) ValidateBasic() error {
 
 // GetSignBytes encodes the message for signing
 func (msg MsgUpdateWhiteListValidator) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
-	if err != nil {
-		panic(err)
-	}
-
-	return sdk.MustSortJSON(b)
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
 }
 
 // GetSigners defines whose signature is required


### PR DESCRIPTION
Rest API txs return with a verification error when we use standard json encoding instead of the encoding designed for the codec.