### PR TITLE
update transaction interval to 10 seconds.

### DIFF
--- a/cmd/ebrelayer/relayer/ethereum.go
+++ b/cmd/ebrelayer/relayer/ethereum.go
@@ -37,6 +37,10 @@ import (
 	ethbridge "github.com/Sifchain/sifnode/x/ethbridge/types"
 )
 
+const (
+	transactionInterval = 10 * time.Second
+)
+
 // TODO: Move relay functionality out of EthereumSub into a new Relayer parent struct
 
 // EthereumSub is an Ethereum listener that can relay txs to Cosmos and Ethereum
@@ -200,8 +204,8 @@ func (sub EthereumSub) Start(completionEvent *sync.WaitGroup) {
 					events := sub.EventsBuffer.GetHeaderEvents()
 					for _, event := range events {
 						err := sub.handleEthereumEvent(event)
-						// Sleep 3 seconds before send next transaction to cosmos, guarantee correct sequence number
-						time.Sleep(3 * time.Second)
+						// Sleep 10 seconds before send next transaction to cosmos, guarantee correct sequence number
+						time.Sleep(transactionInterval)
 
 						if err != nil {
 							sub.Logger.Error(err.Error())


### PR DESCRIPTION
ebrelayer need longer time for cosmos process the transaction and sync up state before sending next transaction.