### PR TITLE
[Frontend] Fix max button

### DIFF
--- a/ui/app/src/views/CreatePoolPage.vue
+++ b/ui/app/src/views/CreatePoolPage.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         throw new Error("from field amount is not defined");
       if (!toFieldAmount.value)
         throw new Error("to field amount is not defined");
-      if (state.value !== PoolState.VALID_INPUT) return
+      if (state.value !== PoolState.VALID_INPUT) return;
 
       transactionState.value = "confirming";
     }
@@ -210,7 +210,7 @@ export default defineComponent({
           (balance) => balance.asset.symbol === fromSymbol.value
         );
         if (!accountBalance) return;
-        fromAmount.value = accountBalance.subtract("1").toFixed(1);
+        fromAmount.value = accountBalance.toFixed(18);
       },
       shareOfPoolPercent,
       connectedText,

--- a/ui/app/src/views/CreatePoolPage.vue
+++ b/ui/app/src/views/CreatePoolPage.vue
@@ -210,7 +210,7 @@ export default defineComponent({
           (balance) => balance.asset.symbol === fromSymbol.value
         );
         if (!accountBalance) return;
-        fromAmount.value = accountBalance.toFixed(18);
+        fromAmount.value = accountBalance.toFixed(8);
       },
       shareOfPoolPercent,
       connectedText,

--- a/ui/app/src/views/SwapPage.vue
+++ b/ui/app/src/views/SwapPage.vue
@@ -86,7 +86,7 @@ export default defineComponent({
         throw new Error("from field amount is not defined");
       if (!toFieldAmount.value)
         throw new Error("to field amount is not defined");
-      if (state.value !== SwapState.VALID_INPUT) return
+      if (state.value !== SwapState.VALID_INPUT) return;
 
       transactionState.value = "confirming";
     }
@@ -102,6 +102,7 @@ export default defineComponent({
         fromFieldAmount.value,
         toFieldAmount.value.asset
       );
+
       transactionHash.value = tx?.transactionHash ?? "";
       transactionState.value = "confirmed";
       clearAmounts();
@@ -181,7 +182,7 @@ export default defineComponent({
           (balance) => balance.asset.symbol === fromSymbol.value
         );
         if (!accountBalance) return;
-        fromAmount.value = accountBalance.subtract("1").toFixed(1);
+        fromAmount.value = accountBalance.toFixed(18);
       },
       nextStepAllowed: computed(() => {
         return state.value === SwapState.VALID_INPUT;

--- a/ui/core/src/entities/AssetAmount.ts
+++ b/ui/core/src/entities/AssetAmount.ts
@@ -102,12 +102,20 @@ export class _AssetAmount implements IAssetAmount {
     return this.fraction.lessThan(other);
   }
 
+  public lessThanOrEqual(other: IFraction | BigintIsh) {
+    return this.fraction.greaterThanOrEqual(other);
+  }
+
   public equalTo(other: IFraction | BigintIsh) {
     return this.fraction.equalTo(other);
   }
 
   public greaterThan(other: IFraction | BigintIsh) {
     return this.fraction.greaterThan(other);
+  }
+
+  public greaterThanOrEqual(other: IFraction | BigintIsh) {
+    return this.fraction.greaterThanOrEqual(other);
   }
 
   public multiply(other: IFraction | BigintIsh) {

--- a/ui/core/src/entities/fraction/Fraction.ts
+++ b/ui/core/src/entities/fraction/Fraction.ts
@@ -79,8 +79,10 @@ export interface IFraction {
   add(other: IFraction | BigintIsh): IFraction;
   subtract(other: IFraction | BigintIsh): IFraction;
   lessThan(other: IFraction | BigintIsh): boolean;
+  lessThanOrEqual(other: IFraction | BigintIsh): boolean;
   equalTo(other: IFraction | BigintIsh): boolean;
   greaterThan(other: IFraction | BigintIsh): boolean;
+  greaterThanOrEqual(other: IFraction | BigintIsh): boolean;
   multiply(other: IFraction | BigintIsh): IFraction;
   divide(other: IFraction | BigintIsh): IFraction;
   toSignificant(
@@ -172,6 +174,10 @@ export class Fraction implements IFraction {
     );
   }
 
+  public lessThanOrEqual(other: IFraction | BigintIsh): boolean {
+    return this.lessThan(other) || this.equalTo(other);
+  }
+
   public equalTo(other: IFraction | BigintIsh): boolean {
     const otherParsed = ensureFraction(other);
 
@@ -188,6 +194,10 @@ export class Fraction implements IFraction {
       JSBI.multiply(this.numerator, otherParsed.denominator),
       JSBI.multiply(otherParsed.numerator, this.denominator)
     );
+  }
+
+  public greaterThanOrEqual(other: IFraction | BigintIsh): boolean {
+    return this.greaterThan(other) || this.equalTo(other);
   }
 
   public multiply(other: IFraction | BigintIsh): IFraction {

--- a/ui/core/src/hooks/addLiquidityCalculator.test.ts
+++ b/ui/core/src/hooks/addLiquidityCalculator.test.ts
@@ -154,5 +154,43 @@ describe("addLiquidityCalculator", () => {
     expect(aPerBRatioMessage.value).toBe("N/A");
     expect(bPerARatioMessage.value).toBe("N/A");
   });
-  
+
+  test("insufficient funds", () => {
+    balances.value = [AssetAmount(ATK, "100"), AssetAmount(ROWAN, "100")];
+    fromAmount.value = "1000";
+    toAmount.value = "500";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+
+    expect(state.value).toBe(PoolState.INSUFFICIENT_FUNDS);
+  });
+
+  test("valid funds below limit", () => {
+    balances.value = [AssetAmount(ATK, "1000"), AssetAmount(ROWAN, "500")];
+    fromAmount.value = "999";
+    toAmount.value = "499";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+    expect(state.value).toBe(PoolState.VALID_INPUT);
+  });
+
+  test("valid funds at limit", () => {
+    balances.value = [AssetAmount(ATK, "1000"), AssetAmount(ROWAN, "500")];
+    fromAmount.value = "1000";
+    toAmount.value = "500";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+
+    expect(state.value).toBe(PoolState.VALID_INPUT);
+  });
+
+  test("invalid funds above limit", () => {
+    balances.value = [AssetAmount(ATK, "1000"), AssetAmount(ROWAN, "500")];
+    fromAmount.value = "1001";
+    toAmount.value = "501";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+
+    expect(state.value).toBe(PoolState.INSUFFICIENT_FUNDS);
+  });
 });

--- a/ui/core/src/hooks/addLiquidityCalculator.ts
+++ b/ui/core/src/hooks/addLiquidityCalculator.ts
@@ -46,22 +46,18 @@ export function usePoolCalculator(input: {
       : null;
   });
 
-  const fromBalanceOverdrawn = computed(
-    // () => !fromBalance.value?.greaterThan(fromField.fieldAmount.value || "0")
-    () => fromBalance.value?.lessThan(fromField.fieldAmount.value || "0")
-  );
+  const fromBalanceOverdrawn = computed(() => {
+    return !fromBalance.value?.greaterThanOrEqual(
+      fromField.fieldAmount.value || "0"
+    );
+  });
 
   const toBalanceOverdrawn = computed(
-    // () => !toBalance.value?.greaterThan(toField.fieldAmount.value || "0")
-    () => toBalance.value?.lessThan(toField.fieldAmount.value || "0")
+    () => !toBalance.value?.greaterThanOrEqual(toField.fieldAmount.value || "0")
   );
 
   const preExistingPool = computed(() => {
-    if (
-      !fromField.asset.value ||
-      !toField.asset.value
-    )
-      return null;
+    if (!fromField.asset.value || !toField.asset.value) return null;
 
     // Find pool from poolFinder
     const pool = input.poolFinder(
@@ -147,13 +143,13 @@ export function usePoolCalculator(input: {
   const aPerBRatioMessage = computed(() => {
     const aAmount = fromField.fieldAmount.value;
     const bAmount = toField.fieldAmount.value;
-    
+
     if (!aAmount || aAmount.equalTo("0")) return ""; // invalid, must supply external
     if (!bAmount || bAmount.equalTo("0")) {
       // if rowan is 0 or empty ...
       // allow if the pool exists (BUT ratio is inapplicable - N/A),
       // invalid if the pool doesn't exist - ""
-      return preExistingPool.value ? "N/A" : ""; 
+      return preExistingPool.value ? "N/A" : "";
     }
 
     return aAmount.divide(bAmount).toFixed(8);
@@ -169,7 +165,7 @@ export function usePoolCalculator(input: {
       // if rowan is 0 or empty ...
       // allow if the pool exists (BUT ratio is inapplicable - N/A),
       // invalid if the pool doesn't exist - ""
-      return preExistingPool.value ? "N/A" : ""; 
+      return preExistingPool.value ? "N/A" : "";
     }
 
     return bAmount.divide(aAmount).toFixed(8);
@@ -181,18 +177,19 @@ export function usePoolCalculator(input: {
 
     if (!input.fromSymbol.value || !input.toSymbol.value)
       return PoolState.SELECT_TOKENS;
-    
-    if (fromBalanceOverdrawn.value || toBalanceOverdrawn.value) 
-      return PoolState.INSUFFICIENT_FUNDS;
 
-    if (!aAmount || aAmount.equalTo("0"))
-      return PoolState.ZERO_AMOUNTS;
+    if (!aAmount || aAmount.equalTo("0")) return PoolState.ZERO_AMOUNTS;
 
     if (!bAmount || bAmount.equalTo("0"))
       // if rowan is 0 or empty ...
       // allow if the pool exists
       // invalid if the pool doesn't exist - ""
-      return preExistingPool.value ? PoolState.VALID_INPUT : PoolState.ZERO_AMOUNTS;
+      return preExistingPool.value
+        ? PoolState.VALID_INPUT
+        : PoolState.ZERO_AMOUNTS;
+
+    if (fromBalanceOverdrawn.value || toBalanceOverdrawn.value)
+      return PoolState.INSUFFICIENT_FUNDS;
 
     return PoolState.VALID_INPUT;
   });

--- a/ui/core/src/hooks/swapCalculator.test.ts
+++ b/ui/core/src/hooks/swapCalculator.test.ts
@@ -52,7 +52,7 @@ describe("swapCalculator", () => {
       toSymbol,
       poolFinder,
       priceImpact,
-      providerFee
+      providerFee,
     }));
     selectedField.value = "from";
     expect(state.value).toBe(SwapState.SELECT_TOKENS);
@@ -142,7 +142,7 @@ describe("swapCalculator", () => {
       toSymbol,
       poolFinder,
       priceImpact,
-      providerFee
+      providerFee,
     }));
 
     selectedField.value = "from";
@@ -151,5 +151,44 @@ describe("swapCalculator", () => {
     fromSymbol.value = "atk";
     toSymbol.value = "btk";
     expect(priceMessage.value).toBe("");
+  });
+
+  test("insufficient funds", () => {
+    balances.value = [AssetAmount(ATK, "100"), AssetAmount(ROWAN, "100")];
+    fromAmount.value = "1000";
+    toAmount.value = "500";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+
+    expect(state.value).toBe(SwapState.INSUFFICIENT_FUNDS);
+  });
+
+  test("valid funds below limit", () => {
+    balances.value = [AssetAmount(ATK, "1000"), AssetAmount(ROWAN, "500")];
+    fromAmount.value = "999";
+    toAmount.value = "499";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+    expect(state.value).toBe(SwapState.VALID_INPUT);
+  });
+
+  test("valid funds at limit", () => {
+    balances.value = [AssetAmount(ATK, "1000"), AssetAmount(ROWAN, "500")];
+    fromAmount.value = "1000";
+    toAmount.value = "500";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+
+    expect(state.value).toBe(SwapState.VALID_INPUT);
+  });
+
+  test("invalid funds above limit", () => {
+    balances.value = [AssetAmount(ATK, "1000"), AssetAmount(ROWAN, "500")];
+    fromAmount.value = "1001";
+    toAmount.value = "501";
+    fromSymbol.value = "atk";
+    toSymbol.value = "rowan";
+
+    expect(state.value).toBe(SwapState.INSUFFICIENT_FUNDS);
   });
 });

--- a/ui/core/src/hooks/swapCalculator.ts
+++ b/ui/core/src/hooks/swapCalculator.ts
@@ -160,7 +160,7 @@ export function useSwapCalculator(input: {
       toField.fieldAmount.value?.equalTo("0")
     )
       return SwapState.ZERO_AMOUNTS;
-    if (!balance.value?.greaterThan(fromField.fieldAmount.value || "0"))
+    if (!balance.value?.greaterThanOrEqual(fromField.fieldAmount.value || "0"))
       return SwapState.INSUFFICIENT_FUNDS;
 
     return SwapState.VALID_INPUT;


### PR DESCRIPTION
When Max button was built there appeared to be some issues with sending transactions that maxed out accounts and we needed to supply amounts just shy of the max. To compensate the max button filled out balance close to the max amount but just shy of it as a temporary measure. It now appears that we can remove this as our product has stabilised. 

* Boundary tests
* Added new `lessThanOrEqual` and `greaterThanOrEqual` methods on `AssetAmount` and `Fraction`
