### PR TITLE
Fix liquidity calulator without preexisting liquidity

### DIFF
--- a/ui/app/src/views/CreatePoolPage.vue
+++ b/ui/app/src/views/CreatePoolPage.vue
@@ -78,25 +78,24 @@ export default defineComponent({
       shareOfPool,
       shareOfPoolPercent,
       totalLiquidityProviderUnits,
-      fromFieldAmount,
-      toFieldAmount,
+      tokenAFieldAmount,
+      tokenBFieldAmount,
       preExistingPool,
       state,
     } = usePoolCalculator({
       balances,
-      fromAmount,
-      toAmount,
-      fromSymbol,
-      selectedField,
-      toSymbol,
+      tokenAAmount: fromAmount,
+      tokenBAmount: toAmount,
+      tokenASymbol: fromSymbol,
+      tokenBSymbol: toSymbol,
       poolFinder,
       liquidityProvider,
     });
 
     function handleNextStepClicked() {
-      if (!fromFieldAmount.value)
+      if (!tokenAFieldAmount.value)
         throw new Error("from field amount is not defined");
-      if (!toFieldAmount.value)
+      if (!tokenBFieldAmount.value)
         throw new Error("to field amount is not defined");
       if (state.value !== PoolState.VALID_INPUT) return;
 
@@ -104,15 +103,15 @@ export default defineComponent({
     }
 
     async function handleAskConfirmClicked() {
-      if (!fromFieldAmount.value)
+      if (!tokenAFieldAmount.value)
         throw new Error("Token A field amount is not defined");
-      if (!toFieldAmount.value)
+      if (!tokenBFieldAmount.value)
         throw new Error("Token B field amount is not defined");
 
       transactionState.value = "signing";
       let tx = await actions.clp.addLiquidity(
-        toFieldAmount.value,
-        fromFieldAmount.value
+        tokenBFieldAmount.value,
+        tokenAFieldAmount.value
       );
 
       console.log("POOL transaction hash: ", tx);


### PR DESCRIPTION
* Fix bug which was zeroing liquidity amount on add liquidity calculator.
* Refactored from/to field to tokenA/tokenB to make more sense
* Updated tests