### PR TITLE
[ui] Turn off inheriting attrs for component dialogs to avoid double event firing

### DIFF
--- a/ui/app/src/components/confirmationDialog/ConfirmationDialog.vue
+++ b/ui/app/src/components/confirmationDialog/ConfirmationDialog.vue
@@ -15,6 +15,7 @@ export type ConfirmState =
 
 export default defineComponent({
   components: { AskConfirmation, AnimatedConfirmation },
+  inheritAttrs: false,
   props: {
     state: { type: String as PropType<ConfirmState>, default: "confirming" },
     requestClose: Function,
@@ -41,7 +42,7 @@ export default defineComponent({
 
     return {
       confirmed,
-      failed
+      failed,
     };
   },
 });

--- a/ui/app/src/components/confirmationDialog/PoolConfirmationDialog.vue
+++ b/ui/app/src/components/confirmationDialog/PoolConfirmationDialog.vue
@@ -16,6 +16,7 @@ export type ConfirmState =
 
 export default defineComponent({
   components: { AskConfirmation, AnimatedConfirmation },
+  inheritAttrs: false,
   props: {
     state: { type: String as PropType<ConfirmState>, default: "confirming" },
     requestClose: Function,

--- a/ui/app/src/components/confirmationDialog/RemoveConfirmationDialog.vue
+++ b/ui/app/src/components/confirmationDialog/RemoveConfirmationDialog.vue
@@ -15,6 +15,7 @@ export type ConfirmState =
 
 export default defineComponent({
   components: { AskConfirmation, AnimatedConfirmation },
+  inheritAttrs: false,
   props: {
     state: { type: String as PropType<ConfirmState>, default: "confirming" },
     requestClose: Function,


### PR DESCRIPTION
This avoid the double keplr popup that can also result in the `Request Rejected` error in notifications.

https://app.asana.com/0/1199521986937893/1199701491050017