### PR TITLE
[ui] bug/decimals

### DIFF
--- a/ui/app/src/components/shared/AssetList.vue
+++ b/ui/app/src/components/shared/AssetList.vue
@@ -2,7 +2,7 @@
   <div class="asset-list">
     <div class="line" v-for="item in items" :key="item.asset.symbol">
       <AssetItem class="token" :symbol="item.asset.symbol" />
-      <div class="amount">{{ item.amount || "0" }}</div>
+      <div class="amount">{{ formatNumber(item.amount) }}</div>
       <div class="action">
         <slot v-if="!!item.amount" :asset="item"></slot>
       </div>
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { PropType, defineComponent } from "vue";
 import AssetItem from "@/components/shared/AssetItem.vue";
-
+import { formatNumber } from "@/components/shared/utils.ts"
 import { Asset } from "ui-core";
 import { computed } from "@vue/reactivity";
 export default defineComponent({
@@ -23,6 +23,9 @@ export default defineComponent({
   props: {
     items: { type: Array as PropType<{ amount: string; asset: Asset }[]> },
   },
+  methods: {
+    formatNumber
+  }
 });
 </script>
 

--- a/ui/app/src/components/shared/utils.ts
+++ b/ui/app/src/components/shared/utils.ts
@@ -16,6 +16,7 @@ export function formatPercentage(amount: string) {
 }
 // TODO: make this work for AssetAmounts and Fractions / Amounts
 export function formatNumber(displayNumber: string) {
+  if (!displayNumber) return "0"
   const amount = parseFloat(displayNumber);
   if (amount < 100000) {
     return amount.toFixed(5);

--- a/ui/app/src/views/PegAssetPage.vue
+++ b/ui/app/src/views/PegAssetPage.vue
@@ -110,7 +110,7 @@ export default defineComponent({
 
     const nextStepAllowed = computed(() => {
       const amountNum = new BigNumber(amount.value);
-      const balance = accountBalance.value?.toFixed(18) ?? "0.0";
+      const balance = accountBalance.value?.toFixed() ?? "0.0";
       return (
         amountNum.isGreaterThan("0.0") &&
         address.value !== "" &&

--- a/ui/app/src/views/PegListingPage.vue
+++ b/ui/app/src/views/PegListingPage.vue
@@ -100,7 +100,7 @@ export default defineComponent({
           if (!amount) return { amount: "", asset };
 
           return {
-            amount: amount.toFixed(amount.asset.decimals === 0 ? 0 : 6),
+            amount,
             asset,
           };
         });


### PR DESCRIPTION
This applies particularly to display values. Fixes future issue where app would crash if decimals of asset on pegAssetPage < 18. This would apply to main net tokens like `USDT` which have 6 decimals. 

Also, applies `formatNumber` in AssetList (Peg)