### PR TITLE
[ui] app/CreatePoolPage: fix back link logic

### DIFF
--- a/ui/app/src/views/CreatePoolPage.vue
+++ b/ui/app/src/views/CreatePoolPage.vue
@@ -238,7 +238,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <Layout class="pool" :backLink="`${fromSymbol && connected && aPerBRatioMessage === 'N/A'
+  <Layout class="pool" :backLink="`${fromSymbol && connected && aPerBRatioMessage > 0
     ? '/pool/' + fromSymbol : '/pool' }`" :title="title">
     <Modal @close="handleSelectClosed">
       <template v-slot:activator="{ requestOpen }">


### PR DESCRIPTION
Fixes issue where back button from `/pool/add-liquidity/<token>` went back to `/pool` instead of `/pool/<token>` 