### PR TITLE
Fix issue with tabs showing the wrong peg/unpeg buttons. Remove bad config

### DIFF
--- a/ui/app/src/components/shared/Tabs.vue
+++ b/ui/app/src/components/shared/Tabs.vue
@@ -54,21 +54,11 @@
 }
 </style>
 <script lang="ts">
-import {
-  defineComponent,
-  EmitsOptions,
-  provide,
-  ref,
-  RendererElement,
-  RendererNode,
-  SetupContext,
-  VNode,
-} from "vue";
-import { effect } from "@vue/reactivity";
+import { defineComponent, provide, ref } from "vue";
 export default defineComponent({
   emits: ["tabselected"],
   props: ["defaultIndex"],
-  setup(props, context: SetupContext<EmitsOptions>) {
+  setup(props, context) {
     const selectedIndex = ref(props.defaultIndex || 0);
     const slots = (context.slots.default && context.slots.default()) ?? [];
     const tabs = slots.map((s: any) => ({ name: (s.props as any).title }));

--- a/ui/app/src/components/shared/Tabs.vue
+++ b/ui/app/src/components/shared/Tabs.vue
@@ -55,6 +55,7 @@
 </style>
 <script lang="ts">
 import {
+  defineComponent,
   EmitsOptions,
   provide,
   ref,
@@ -64,13 +65,16 @@ import {
   VNode,
 } from "vue";
 import { effect } from "@vue/reactivity";
-export default {
+export default defineComponent({
   emits: ["tabselected"],
-  setup(_: any, context: SetupContext<EmitsOptions>) {
-    const selectedIndex = ref(1);
+  props: ["defaultIndex"],
+  setup(props, context: SetupContext<EmitsOptions>) {
+    const selectedIndex = ref(props.defaultIndex || 0);
     const slots = (context.slots.default && context.slots.default()) ?? [];
     const tabs = slots.map((s: any) => ({ name: (s.props as any).title }));
-    const selectedTitle = ref<string | undefined>(tabs[0].name);
+    const selectedTitle = ref<string | undefined>(
+      tabs[selectedIndex.value].name
+    );
 
     function tabSelected(index: number) {
       const selectedProps = tabs[index].name;
@@ -90,5 +94,5 @@ export default {
       tabs,
     };
   },
-};
+});
 </script>

--- a/ui/app/src/views/PegListingPage.vue
+++ b/ui/app/src/views/PegListingPage.vue
@@ -8,7 +8,7 @@
         v-model="searchText"
       />
     </div>
-    <Tabs @tabselected="onTabSelected">
+    <Tabs :defaultIndex="1" @tabselected="onTabSelected">
       <Tab title="External Tokens">
         <AssetList :items="assetList" v-slot="{ asset }">
           <SifButton

--- a/ui/core/src/assets.ethereum.localnet.json
+++ b/ui/core/src/assets.ethereum.localnet.json
@@ -46,48 +46,6 @@
       "name": "Chainlink",
       "address": "0xBd2c938B9F6Bfc1A66368D08CB44dC3EB2aE27bE",
       "network": "ethereum"
-    },
-    {
-      "symbol": "rowan",
-      "decimals": 18,
-      "name": "Rowan",
-      "imageUrl": "./images/siflogo.png",
-      "network": "sifchain"
-    },
-    {
-      "symbol": "cdtoken",
-      "decimals": 18,
-      "imageUrl": "https://assets.coingecko.com/coins/images/279/large/ethereum.png",
-      "name": "cdtoken",
-      "network": "sifchain"
-    },
-    {
-      "symbol": "ceth",
-      "decimals": 18,
-      "imageUrl": "https://assets.coingecko.com/coins/images/279/large/ethereum.png",
-      "name": "ceth",
-      "network": "sifchain"
-    },
-    {
-      "symbol": "cctoken",
-      "decimals": 18,
-      "imageUrl": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
-      "name": "cctoken",
-      "network": "sifchain"
-    },
-    {
-      "symbol": "cbtoken",
-      "imageUrl": "https://assets.coingecko.com/coins/images/877/large/chainlink-new-logo.png",
-      "decimals": 18,
-      "name": "cbtoken",
-      "network": "sifchain"
-    },
-    {
-      "symbol": "cacoin",
-      "decimals": 18,
-      "imageUrl": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
-      "name": "cacoin",
-      "network": "sifchain"
     }
   ]
 }


### PR DESCRIPTION
There was an issue with the tab component where it was not setup to manage defaults properly.

This adds a `defaultIndex` prop to manage the default selected Index.

This meant that the wrong token peg and unpeg links were being shown to the user which meant that peg and unpeg were not working when clicked through

There was also some bad config in the localconfig where sifchain assets were being listed in the ethereum asset config.
