### PR TITLE
[ui] core/ethBridgeService: hard code gas limit for burn

### DIFF
--- a/ui/core/src/api/EthbridgeService/EthbridgeService.ts
+++ b/ui/core/src/api/EthbridgeService/EthbridgeService.ts
@@ -248,6 +248,7 @@ export default function createEthbridgeService({
         const sendArgs = {
           from: fromAddress,
           value: 0,
+          gas: 100000 // Note: This chose in lieu of burn(params).estimateGas({from})
         };
 
         bridgeBankContract.methods

--- a/ui/core/src/api/EthbridgeService/EthbridgeService.ts
+++ b/ui/core/src/api/EthbridgeService/EthbridgeService.ts
@@ -248,7 +248,7 @@ export default function createEthbridgeService({
         const sendArgs = {
           from: fromAddress,
           value: 0,
-          gas: 100000 // Note: This chose in lieu of burn(params).estimateGas({from})
+          gas: 150000 // Note: This chose in lieu of burn(params).estimateGas({from})
         };
 
         bridgeBankContract.methods


### PR DESCRIPTION
Issue #789. 

Some users see huge gas fee when peg erowan (`burn`). This fix hard codes the gas estimate at `150000` (bumped to 150k per Eliot recommendation). Most transactions used between 40-55k gas (Reference: https://etherscan.io/address/0xb5f54ac4466f5ce7e0d8a5cb9fe7b8c0f35b7ba8). An alternate method to solve this issue is to invoke `burn(params).gasEstimate({fromAddress})`.