### PR TITLE
[ui-hotfix] Remove liquidity pool from pool list

### DIFF
--- a/ui/core/src/actions/clp/index.ts
+++ b/ui/core/src/actions/clp/index.ts
@@ -50,6 +50,19 @@ export default ({
 
         store.accountpools[state.address][pool] = { lp, pool };
       });
+
+      // Delete accountpools
+      const currentPoolIds = accountPoolSymbols.map(id => `${id}_rowan`);
+      if (store.accountpools[state.address]) {
+        const existingPoolIds = Object.keys(store.accountpools[state.address]);
+        const disjunctiveIds = existingPoolIds.filter(
+          id => !currentPoolIds.includes(id)
+        );
+
+        disjunctiveIds.forEach(poolToRemove => {
+          delete store.accountpools[state.address][poolToRemove];
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Because we are not just blowing away an array anymore and have replaced with a hash remove liquidity was not updating the list of pools. We don't have the option of blowing away the object or that will cause flicker as new pools load so. We need to go through each individually and remove them.