### PR TITLE
[testnet-hotfix][ui] ui/core: testnet, devnet chainId (semi) fix

### DIFF
--- a/ui/core/src/config.devnet.json
+++ b/ui/core/src/config.devnet.json
@@ -3,7 +3,7 @@
   "sifApiUrl": "https://api-devnet.sifchain.finance/",
   "sifWsUrl": "wss://rpc-devnet.sifchain.finance/websocket",
   "sifRpcUrl": "https://rpc-devnet.sifchain.finance/",
-  "sifChainId": "sandpit",
+  "sifChainId": "sifchain",
   "web3Provider": "metamask",
   "nativeAsset": "rowan",
   "bridgebankContractAddress": "0x3FA07beAB77235A3728eF3911A9983579882666D",

--- a/ui/core/src/config.devnet.json
+++ b/ui/core/src/config.devnet.json
@@ -3,7 +3,7 @@
   "sifApiUrl": "https://api-devnet.sifchain.finance/",
   "sifWsUrl": "wss://rpc-devnet.sifchain.finance/websocket",
   "sifRpcUrl": "https://rpc-devnet.sifchain.finance/",
-  "sifChainId": "sifchain",
+  "sifChainId": "sifchain-devnet",
   "web3Provider": "metamask",
   "nativeAsset": "rowan",
   "bridgebankContractAddress": "0x3FA07beAB77235A3728eF3911A9983579882666D",

--- a/ui/core/src/config.testnet.json
+++ b/ui/core/src/config.testnet.json
@@ -3,7 +3,7 @@
   "sifApiUrl": "https://api-testnet.sifchain.finance/",
   "sifWsUrl": "wss://rpc-testnet.sifchain.finance/websocket",
   "sifRpcUrl": "https://rpc-testnet.sifchain.finance/",
-  "sifChainId": "sandpit",
+  "sifChainId": "sifchain",
   "web3Provider": "metamask",
   "nativeAsset": "rowan",
   "bridgebankContractAddress": "0x1E234d1747ff8F4D365acA9b61bd7fd3F585B2ce",

--- a/ui/core/src/config.testnet.json
+++ b/ui/core/src/config.testnet.json
@@ -3,7 +3,7 @@
   "sifApiUrl": "https://api-testnet.sifchain.finance/",
   "sifWsUrl": "wss://rpc-testnet.sifchain.finance/websocket",
   "sifRpcUrl": "https://rpc-testnet.sifchain.finance/",
-  "sifChainId": "sifchain",
+  "sifChainId": "sifchain-testnet",
   "web3Provider": "metamask",
   "nativeAsset": "rowan",
   "bridgebankContractAddress": "0x1E234d1747ff8F4D365acA9b61bd7fd3F585B2ce",


### PR DESCRIPTION
UI fix to rename `testnet` and `devnet` chains to `sifchain-testnet` and `sifchain-devnet` respectively. This will allow for Keplr to properly differentiate between environments so transactions are broadcast to the right endpoints.