### PR TITLE
Truffle update requires no sudo for install

### DIFF
--- a/test/integration/setup-linux-environment-user.sh
+++ b/test/integration/setup-linux-environment-user.sh
@@ -9,7 +9,7 @@ npm config set prefix '~/.npm-global'
 
 # npm install of these succeeds, but then returns 1 as its exit value.  Just
 # assume it worked; if it didn't, everything will die immediately
-sudo npm install -g truffle @truffle/hdwallet-provider ganache-cli || true
+npm install -g truffle @truffle/hdwallet-provider ganache-cli || true
 
 # these npm packages were written correctly
 sudo npm install -g dotenv


### PR DESCRIPTION
Possible fix for our truffle issue.  We used to need sudo to install, and it's possible that we can't use sudo any more.