### PR TITLE
Improve rescue ceth tests

### DIFF
--- a/test/integration/setup-linux-environment-user.sh
+++ b/test/integration/setup-linux-environment-user.sh
@@ -9,7 +9,7 @@ npm config set prefix '~/.npm-global'
 
 # npm install of these succeeds, but then returns 1 as its exit value.  Just
 # assume it worked; if it didn't, everything will die immediately
-sudo npm install -g truffle @truffle/hdwallet-provider ganache-cli || true
+npm install -g truffle @truffle/hdwallet-provider ganache-cli || true
 
 # these npm packages were written correctly
 sudo npm install -g dotenv

--- a/test/integration/src/py/conftest.py
+++ b/test/integration/src/py/conftest.py
@@ -19,6 +19,18 @@ def sifnode_base_dir():
 
 
 @pytest.fixture
+def sifchain_admin_account():
+    return test_utilities.get_required_env_var("SIFCHAIN_ADMIN_ACCOUNT")
+
+
+@pytest.fixture
+def sifchain_admin_account_credentials():
+    return test_utilities.SifchaincliCredentials(
+        from_key="sifnodeadmin"
+    )
+
+
+@pytest.fixture
 def smart_contract_artifact_dir(smart_contracts_dir):
     result = test_utilities.get_optional_env_var("SMART_CONTRACT_ARTIFACT_DIR", None)
     return result if result else os.path.join(smart_contracts_dir, "build/contracts")
@@ -332,3 +344,20 @@ def rowan_source_integrationtest_env_transfer_request(
 def ethbridge_module_address():
     """The hardcoded address of the sifnode ethbridge module"""
     return "sif1l3dftf499u4gvdeuuzdl2pgv4f0xdtnuuwlzp8"
+
+
+@pytest.fixture(scope="function")
+def restore_default_rescue_location(
+        ethbridge_module_address,
+        sifchain_admin_account,
+        sifchain_admin_account_credentials,
+        basic_transfer_request
+):
+    """Restores the ethbridge module as the destination for ceth fees"""
+    yield None
+    test_utilities.update_ceth_receiver_account(
+        receiver_account=ethbridge_module_address,
+        admin_account=sifchain_admin_account,
+        transfer_request=basic_transfer_request,
+        credentials=sifchain_admin_account_credentials
+    )


### PR DESCRIPTION
The previous version of this test could only be run once.  Change the test so it resets the state of the chain and the test can be repeated.