### PR TITLE
[ChainOps] Explorer bugfix.

### DIFF
--- a/deploy/helm/block-explorer/templates/configmap.yaml
+++ b/deploy/helm/block-explorer/templates/configmap.yaml
@@ -301,7 +301,7 @@ data:
         "genesisFile": "{{ .Values.blockExplorer.env.genesisURL }}",
         "remote":{
             "rpc": "{{ .Values.blockExplorer.env.remote.rpcURL }}",
-            "lcd": "{{ .Values.blockExplorer.env.remote.lcdURL }}"
+            "lcd": "{{ .Values.blockExplorer.env.remote.apiURL }}"
         },
         "debug": {
             "startTimer": true,


### PR DESCRIPTION
Includes:

* Fixes a bug where the configmap referenced the old config for the API URL.