### PR TITLE
[ui] hotfix: ui/app/RewardsPage: Multiplier tooltip, decimals

### DIFF
--- a/ui/app/src/components/shared/Icon.vue
+++ b/ui/app/src/components/shared/Icon.vue
@@ -62,7 +62,6 @@ export default defineComponent({
     <Plus v-if="icon === 'plus'" />
     <InfoBoxBlack v-if="icon === 'info-box-black'" />
     <InfoBoxWhite v-if="icon === 'info-box-white'" />
-    <InfoBoxWhite v-if="icon === 'info-box-white'" />
     <Sif v-if="icon === 'sif'" />
     <Exclaimation v-if="icon === 'exclaimation'" />
   </span>

--- a/ui/app/src/views/RewardsPage.vue
+++ b/ui/app/src/views/RewardsPage.vue
@@ -8,6 +8,8 @@ import AssetItem from "@/components/shared/AssetItem.vue";
 import Box from "@/components/shared/Box.vue";
 import { Copy, SubHeading } from "@/components/shared/Text";
 import ActionsPanel from "@/components/actionsPanel/ActionsPanel.vue";
+import Tooltip from "@/components/shared/Tooltip.vue";
+import Icon from "@/components/shared/Icon.vue";
 
 const REWARD_INFO = {
   lm: {
@@ -26,6 +28,20 @@ async function getRewardsData(address: ComputedRef<any>) {
     return [{ type: "lm", multiplier: 0, start: "", amount: null }];
   return await data.json();
 }
+
+// NOTE - This will be removed and replaced with Amount API
+function format(amount: number) {
+  if (amount < 1) {
+    return amount.toFixed(6);
+  } else if (amount < 1000) {
+    return amount.toFixed(4);
+  } else if (amount < 100000) {
+    return amount.toFixed(2);
+  } else {
+    return amount.toFixed(0);
+  }
+}
+
 export default defineComponent({
   components: {
     Layout,
@@ -35,6 +51,8 @@ export default defineComponent({
     Copy,
     SubHeading,
     Box,
+    Tooltip,
+    Icon,
   },
   setup() {
     const { store } = useCore();
@@ -52,6 +70,7 @@ export default defineComponent({
     return {
       rewards,
       REWARD_INFO,
+      format,
     };
   },
 });
@@ -83,9 +102,17 @@ export default defineComponent({
             <div class="amount-container w50 jcsb">
               <div class="df fdr">
                 <AssetItem symbol="Rowan" :label="false" />
-                <span>{{ reward.amount ? reward.amount?.toFixed() : 0 }}</span>
+                <span>{{ format(+reward.amount) }}</span>
               </div>
               <span>ROWAN</span>
+              <Tooltip>
+                <template #message>
+                  <div class="tooltip">
+                    Current multiplier: {{ format(+reward.multiplier) }}x
+                  </div>
+                </template>
+                <Icon icon="info-box-black" />
+              </Tooltip>
             </div>
             <a
               class="more-info-button"


### PR DESCRIPTION
This better handles decimal values and includes a tooltip which displays current multiplier.
<img width="516" alt="Screen Shot 2021-04-09 at 3 42 18 PM" src="https://user-images.githubusercontent.com/5235538/114239110-3ecab100-994b-11eb-8ed9-fc7417a1954b.png">
