### PR TITLE
[ui] Feature/prevent unpeg bsc

### DIFF
--- a/ui/app/src/components/shared/SifButton.stories.ts
+++ b/ui/app/src/components/shared/SifButton.stories.ts
@@ -15,4 +15,4 @@ const Template = (args: any) => ({
 });
 
 export const Primary = Template.bind({});
-Primary.args = {};
+(Primary as any).args = {};

--- a/ui/app/src/components/shared/SifButton.vue
+++ b/ui/app/src/components/shared/SifButton.vue
@@ -137,7 +137,8 @@ export default defineComponent({
     margin-right: 0.5em;
   }
 
-  &:disabled {
+  &:disabled,
+  &[disabled="true"] {
     cursor: none;
     pointer-events: none;
     background: $c_gray_400 !important;

--- a/ui/app/src/views/PegAssetPage.vue
+++ b/ui/app/src/views/PegAssetPage.vue
@@ -67,7 +67,6 @@ export default defineComponent({
         return actions.ethWallet.isSupportedNetwork();
       }
 
-      // For now business rules around this are not clear
       return true;
     });
 

--- a/ui/app/src/views/PegAssetPage.vue
+++ b/ui/app/src/views/PegAssetPage.vue
@@ -62,6 +62,15 @@ export default defineComponent({
       return Array.isArray(assetFrom) ? assetFrom[0] : assetFrom;
     });
 
+    const networkIsSupported = computed(() => {
+      if (mode.value === "peg") {
+        return actions.ethWallet.isSupportedNetwork();
+      }
+
+      // For now business rules around this are not clear
+      return true;
+    });
+
     const oppositeSymbol = computed(() => {
       if (mode.value === "peg") {
         return getPeggedSymbol(symbol.value);
@@ -137,16 +146,24 @@ export default defineComponent({
     });
 
     const nextStepAllowed = computed(() => {
+      if (!networkIsSupported.value) return false;
+
       const amountNum = new BigNumber(amount.value);
       const balance =
         (accountBalance.value &&
           format(accountBalance.value.amount, accountBalance.value.asset)) ??
         "0.0";
+
       return (
         amountNum.isGreaterThan("0.0") &&
         address.value !== "" &&
         amountNum.isLessThanOrEqualTo(balance)
       );
+    });
+
+    const nextStepMessage = computed(() => {
+      if (!networkIsSupported.value) return "Network Not Supported";
+      return mode.value === "peg" ? "Peg" : "Unpeg";
     });
 
     function requestTransactionModalClose() {
@@ -210,9 +227,7 @@ export default defineComponent({
       nextStepAllowed,
       isMaxActive,
       feeDisplayAmount,
-      nextStepMessage: computed(() => {
-        return mode.value === "peg" ? "Peg" : "Unpeg";
-      }),
+      nextStepMessage,
     };
     (window as any).pageState = pageState;
     return pageState;

--- a/ui/app/src/views/PegListingPage.vue
+++ b/ui/app/src/views/PegListingPage.vue
@@ -12,6 +12,7 @@
       <Tab title="External Tokens" slug="external-tab">
         <AssetList :items="assetList" v-slot="{ asset }">
           <SifButton
+            :disabled="!asset.supported"
             :to="`/peg/${asset.asset.symbol}/${peggedSymbol(
               asset.asset.symbol,
             )}`"
@@ -19,6 +20,9 @@
             :data-handle="'peg-' + asset.asset.symbol"
             >Peg</SifButton
           >
+          <Tooltip v-if="!asset.supported" message="Network not supported">
+            &nbsp;<Icon icon="info-box-black" />
+          </Tooltip>
         </AssetList>
       </Tab>
       <Tab title="Sifchain Native" slug="native-tab">
@@ -80,12 +84,13 @@ import SifInput from "@/components/shared/SifInput.vue";
 import ActionsPanel from "@/components/actionsPanel/ActionsPanel.vue";
 import SifButton from "@/components/shared/SifButton.vue";
 import Tooltip from "@/components/shared/Tooltip.vue";
+import Icon from "@/components/shared/Icon.vue";
 
 import { useCore } from "@/hooks/useCore";
 import { defineComponent, ref } from "vue";
 import { computed } from "@vue/reactivity";
 import { getUnpeggedSymbol } from "../components/shared/utils";
-import { AssetAmount, TransactionStatus } from "ui-core";
+import { AssetAmount, IAsset, TransactionStatus } from "ui-core";
 
 export default defineComponent({
   components: {
@@ -97,10 +102,20 @@ export default defineComponent({
     SifInput,
     ActionsPanel,
     Tooltip,
+    Icon,
   },
   setup(_, context) {
     const { store, actions } = useCore();
+    function getIsSupportedNetwork(asset: IAsset): boolean {
+      if (asset.network === "ethereum") {
+        return actions.ethWallet.isSupportedNetwork();
+      }
 
+      if (asset.network === "sifchain") {
+        return true; // TODO: Handle the case of whether the network is supported
+      }
+      return false;
+    }
     const searchText = ref("");
     const selectedTab = ref("Sifchain Native");
 
@@ -169,14 +184,23 @@ export default defineComponent({
               )
             : [];
 
+          // Is the asset from a supported network
+          const supported = getIsSupportedNetwork(asset);
+
           if (!amount) {
-            return { amount: AssetAmount(asset, "0"), asset, pegTxs };
+            return {
+              amount: AssetAmount(asset, "0"),
+              asset,
+              pegTxs,
+              supported,
+            };
           }
 
           return {
             amount,
             asset,
             pegTxs,
+            supported,
           };
         })
         .sort((a, b) => {
@@ -217,7 +241,6 @@ export default defineComponent({
       shortenHash,
       assetList,
       searchText,
-
       peggedSymbol(unpeggedSymbol: string) {
         if (unpeggedSymbol.toLowerCase() === "erowan") {
           return "rowan";

--- a/ui/core/src/actions/ethWallet.test.ts
+++ b/ui/core/src/actions/ethWallet.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
     setPhrase: async (phrase: string) => "",
     purgeClient: () => {},
     onProviderNotFound: () => {},
+    onChainIdDetected: () => {},
   };
 
   mockEventBusService = {

--- a/ui/core/src/actions/ethWallet.ts
+++ b/ui/core/src/actions/ethWallet.ts
@@ -1,6 +1,6 @@
 import { effect } from "@vue/reactivity";
 import { ActionContext } from "..";
-import { Asset } from "../entities";
+import { Asset, IAsset } from "../entities";
 import B from "../entities/utils/B";
 
 export default ({
@@ -27,9 +27,20 @@ export default ({
   const etheriumState = api.EthereumService.getState();
 
   const actions = {
+    isSupportedNetwork() {
+      const supportedEthChains = [
+        "0x1", // 1 Mainnet
+        "0x3", // 3 Ropsten
+        "0x539", // 1337 Ganache/Hardhat
+      ];
+
+      return supportedEthChains.includes(store.wallet.eth.chainId ?? "");
+    },
+
     async disconnectWallet() {
       await api.EthereumService.disconnect();
     },
+
     async connectToWallet() {
       try {
         await api.EthereumService.connect();
@@ -43,6 +54,7 @@ export default ({
         });
       }
     },
+
     async transferEthWallet(amount: number, recipient: string, asset: Asset) {
       const hash = await api.EthereumService.transfer({
         amount: B(amount, asset.decimals),

--- a/ui/core/src/actions/ethWallet.ts
+++ b/ui/core/src/actions/ethWallet.ts
@@ -28,13 +28,14 @@ export default ({
 
   const actions = {
     isSupportedNetwork() {
-      const supportedEthChains = [
+      // List of supported EVM chainIds
+      const supportedEVMChainIds = [
         "0x1", // 1 Mainnet
         "0x3", // 3 Ropsten
         "0x539", // 1337 Ganache/Hardhat
       ];
 
-      return supportedEthChains.includes(store.wallet.eth.chainId ?? "");
+      return supportedEVMChainIds.includes(store.wallet.eth.chainId ?? "");
     },
 
     async disconnectWallet() {

--- a/ui/core/src/actions/ethWallet.ts
+++ b/ui/core/src/actions/ethWallet.ts
@@ -20,6 +20,10 @@ export default ({
     });
   });
 
+  api.EthereumService.onChainIdDetected((chainId) => {
+    store.wallet.eth.chainId = chainId;
+  });
+
   const etheriumState = api.EthereumService.getState();
 
   const actions = {

--- a/ui/core/src/actions/ethWallet.ts
+++ b/ui/core/src/actions/ethWallet.ts
@@ -2,6 +2,7 @@ import { effect } from "@vue/reactivity";
 import { ActionContext } from "..";
 import { Asset, IAsset } from "../entities";
 import B from "../entities/utils/B";
+import { isSupportedEVMChain } from "./utils";
 
 export default ({
   api,
@@ -28,14 +29,7 @@ export default ({
 
   const actions = {
     isSupportedNetwork() {
-      // List of supported EVM chainIds
-      const supportedEVMChainIds = [
-        "0x1", // 1 Mainnet
-        "0x3", // 3 Ropsten
-        "0x539", // 1337 Ganache/Hardhat
-      ];
-
-      return supportedEVMChainIds.includes(store.wallet.eth.chainId ?? "");
+      return isSupportedEVMChain(store.wallet.eth.chainId);
     },
 
     async disconnectWallet() {

--- a/ui/core/src/actions/peg/index.ts
+++ b/ui/core/src/actions/peg/index.ts
@@ -140,7 +140,7 @@ export default ({
       );
     },
 
-    async peg(assetAmount: IAssetAmount) {
+    async peg(assetAmount: IAssetAmount): Promise<TransactionStatus> {
       if (
         assetAmount.asset.network === Network.ETHEREUM &&
         !isSupportedEVMChain(store.wallet.eth.chainId)
@@ -151,7 +151,10 @@ export default ({
             message: "EVM Network not supported!",
           },
         });
-        return;
+        return {
+          hash: "",
+          state: "failed",
+        };
       }
 
       const subscribeToTx = SubscribeToTx(ctx);

--- a/ui/core/src/actions/peg/index.ts
+++ b/ui/core/src/actions/peg/index.ts
@@ -5,8 +5,10 @@ import {
   AssetAmount,
   IAsset,
   IAssetAmount,
+  Network,
   TransactionStatus,
 } from "../../entities";
+import { isSupportedEVMChain } from "../utils";
 
 import { SubscribeToUnconfirmedPegTxs } from "./subscribeToUnconfirmedPegTxs";
 import { SubscribeToTx } from "./utils/subscribeToTx";
@@ -139,6 +141,19 @@ export default ({
     },
 
     async peg(assetAmount: IAssetAmount) {
+      if (
+        assetAmount.asset.network === Network.ETHEREUM &&
+        !isSupportedEVMChain(store.wallet.eth.chainId)
+      ) {
+        api.EventBusService.dispatch({
+          type: "ErrorEvent",
+          payload: {
+            message: "EVM Network not supported!",
+          },
+        });
+        return;
+      }
+
       const subscribeToTx = SubscribeToTx(ctx);
 
       const lockOrBurnFn = isOriginallySifchainNativeToken(assetAmount.asset)

--- a/ui/core/src/actions/utils/index.ts
+++ b/ui/core/src/actions/utils/index.ts
@@ -1,0 +1,11 @@
+export function isSupportedEVMChain(chainId?: string) {
+  if (!chainId) return false;
+  // List of supported EVM chainIds
+  const supportedEVMChainIds = [
+    "0x1", // 1 Mainnet
+    "0x3", // 3 Ropsten
+    "0x539", // 1337 Ganache/Hardhat
+  ];
+
+  return supportedEVMChainIds.includes(chainId);
+}

--- a/ui/core/src/api/EthereumService/EthereumService.ts
+++ b/ui/core/src/api/EthereumService/EthereumService.ts
@@ -12,9 +12,11 @@ import {
   IAssetAmount,
 } from "../../entities";
 import {
+  EIPProvider,
   getEtheriumBalance,
   getTokenBalance,
   isEventEmittingProvider,
+  isMetaMaskInpageProvider,
   transferAsset,
 } from "./utils/ethereumUtils";
 
@@ -22,26 +24,19 @@ import { Msg } from "@cosmjs/launchpad";
 
 type Address = string;
 type Balances = IAssetAmount[];
+type PossibleProvider = provider | EIPProvider;
 
 export type EthereumServiceContext = {
   getWeb3Provider: () => Promise<provider>;
   assets: Asset[];
 };
 
-type MetaMaskProvider = WebsocketProvider & {
-  request?: (a: any) => Promise<void>;
-  isConnected(): boolean;
-};
-
-function isMetaMaskProvider(provider?: provider): provider is MetaMaskProvider {
-  return typeof (provider as any).request === "function";
-}
-
 const initState = {
   connected: false,
   accounts: [],
   balances: [],
   address: "",
+  chainId: "",
   log: "unset",
 };
 
@@ -51,9 +46,10 @@ export class EthereumService implements IWalletService {
   private web3: Web3 | null = null;
   private supportedTokens: Asset[] = [];
   private blockSubscription: any;
-  private provider: provider | undefined;
-  private providerPromise: Promise<provider>;
+  private provider: PossibleProvider | undefined;
+  private providerPromise: Promise<PossibleProvider>;
   private reportProviderNotFound = () => {};
+  private chainIdDetectedHandler = (_chainId: string) => {};
 
   // This is shared reactive state
   private state: {
@@ -64,22 +60,34 @@ export class EthereumService implements IWalletService {
     log: string;
   };
 
-  constructor(getWeb3Provider: () => Promise<provider>, assets: Asset[]) {
+  constructor(
+    getWeb3Provider: () => Promise<PossibleProvider>,
+    assets: Asset[],
+  ) {
     this.state = reactive({ ...initState });
     this.supportedTokens = assets.filter((t) => t.network === Network.ETHEREUM);
     this.providerPromise = getWeb3Provider();
     this.providerPromise
       .then((provider) => {
+        // Provider not found
         if (!provider) {
           this.provider = null;
           this.reportProviderNotFound();
           return;
         }
+
         if (isEventEmittingProvider(provider)) {
           provider.on("chainChanged", () => window.location.reload());
           provider.on("accountsChanged", () => this.updateData());
         }
-        this.web3 = new Web3(provider);
+        // What network is the provider on
+        if (isMetaMaskInpageProvider(provider)) {
+          provider.request({ method: "eth_chainId" }).then((chainId) => {
+            this.chainIdDetectedHandler(chainId as string);
+          });
+        }
+
+        this.web3 = new Web3(provider as provider);
         this.provider = provider;
         this.addWeb3Subscription();
         this.updateData();
@@ -87,6 +95,10 @@ export class EthereumService implements IWalletService {
       .catch((error) => {
         console.log("error", error);
       });
+  }
+
+  onChainIdDetected(handler: (chainId: string) => void) {
+    this.chainIdDetectedHandler = handler;
   }
 
   onProviderNotFound(handler: () => void) {
@@ -106,7 +118,8 @@ export class EthereumService implements IWalletService {
         this.state.balances = [];
         return;
       }
-      this.state.connected = !!this.web3;
+
+      this.state.connected = true;
       this.state.accounts = (await this.web3.eth.getAccounts()) ?? [];
       this.state.address = this.state.accounts[0];
       this.state.balances = await this.getBalance();
@@ -133,8 +146,8 @@ export class EthereumService implements IWalletService {
       if (!provider) {
         throw new Error("Cannot connect because provider is not yet loaded!");
       }
-      this.web3 = new Web3(provider);
-      if (isMetaMaskProvider(provider)) {
+      this.web3 = new Web3(provider as provider);
+      if (isMetaMaskInpageProvider(provider)) {
         if (provider.request) {
           await provider.request({ method: "eth_requestAccounts" });
         }
@@ -173,9 +186,9 @@ export class EthereumService implements IWalletService {
   }
 
   async disconnect() {
-    if (isMetaMaskProvider(this.provider)) {
-      this.provider.disconnect &&
-        this.provider.disconnect(0, "Website disconnected wallet");
+    if (isMetaMaskInpageProvider(this.provider)) {
+      (this.provider as any).disconnect &&
+        (this.provider as any).disconnect(0, "Website disconnected wallet");
     }
     this.removeWeb3Subscription();
     this.web3 = null;

--- a/ui/core/src/api/EthereumService/EthereumService.ts
+++ b/ui/core/src/api/EthereumService/EthereumService.ts
@@ -36,7 +36,6 @@ const initState = {
   accounts: [],
   balances: [],
   address: "",
-  chainId: "",
   log: "unset",
 };
 

--- a/ui/core/src/api/EthereumService/utils/ethereumUtils.ts
+++ b/ui/core/src/api/EthereumService/utils/ethereumUtils.ts
@@ -1,3 +1,4 @@
+import { MetaMaskInpageProvider } from "@metamask/inpage-provider";
 import JSBI from "jsbi";
 import Web3 from "web3";
 import {
@@ -31,10 +32,19 @@ export async function getTokenBalance(
 }
 
 export function isEventEmittingProvider(
-  provider?: provider,
+  provider?: unknown,
 ): provider is WebsocketProvider | IpcProvider {
   if (!provider || typeof provider === "string") return false;
   return typeof (provider as any).on === "function";
+}
+
+export type EIPProvider = MetaMaskInpageProvider;
+
+export function isMetaMaskInpageProvider(
+  provider?: unknown,
+): provider is EIPProvider {
+  if (!provider || typeof provider === "string") return false;
+  return typeof (provider as any).request === "function";
 }
 
 // Transfer token or ether

--- a/ui/core/src/api/IWalletService.ts
+++ b/ui/core/src/api/IWalletService.ts
@@ -11,6 +11,7 @@ export type IWalletService = {
     log: string;
   };
   onProviderNotFound(handler: () => void): void;
+  onChainIdDetected(handler: (chainId: string) => void): void;
   isConnected(): boolean;
   getSupportedTokens: () => Asset[];
   connect(): Promise<void>;

--- a/ui/core/src/api/SifService/SifService.ts
+++ b/ui/core/src/api/SifService/SifService.ts
@@ -149,7 +149,6 @@ export default function createSifService({
       if (!keplrProvider) {
         return;
       }
-      console.log("setClient");
       if (connecting || state.connected) {
         return;
       }

--- a/ui/core/src/store/wallet.ts
+++ b/ui/core/src/store/wallet.ts
@@ -18,7 +18,6 @@ export type WalletStore = {
 
 export const wallet = reactive<WalletStore>({
   eth: {
-    chainId: "",
     isConnected: false,
     address: "",
     balances: [],

--- a/ui/core/src/store/wallet.ts
+++ b/ui/core/src/store/wallet.ts
@@ -4,6 +4,7 @@ import { Address, IAssetAmount } from "../entities";
 
 export type WalletStore = {
   eth: {
+    chainId?: string; // 0x1 is mainnet
     balances: IAssetAmount[];
     isConnected: boolean;
     address: Address;

--- a/ui/core/src/store/wallet.ts
+++ b/ui/core/src/store/wallet.ts
@@ -4,7 +4,7 @@ import { Address, IAssetAmount } from "../entities";
 
 export type WalletStore = {
   eth: {
-    chainId?: string; // 0x1 is mainnet
+    chainId?: string;
     balances: IAssetAmount[];
     isConnected: boolean;
     address: Address;
@@ -18,6 +18,7 @@ export type WalletStore = {
 
 export const wallet = reactive<WalletStore>({
   eth: {
+    chainId: "",
     isConnected: false,
     address: "",
     balances: [],

--- a/ui/core/src/test/utils/getMockWalletService.ts
+++ b/ui/core/src/test/utils/getMockWalletService.ts
@@ -33,5 +33,6 @@ export function getMockWalletService(
       memo?: string,
     ) => {},
     onProviderNotFound: () => {},
+    onChainIdDetected: () => {},
   };
 }


### PR DESCRIPTION
This PR disables pegging when the user is not connected to a supported EVM network. 

After consultation with @j-kappa this adds a few interim (not fancily designed) usability guards for when connecting to an unsupported EVM network:

![image](https://user-images.githubusercontent.com/1256409/114985706-764ed580-9ed6-11eb-91b6-e7041d1343ff.png)

![image](https://user-images.githubusercontent.com/1256409/114985547-46073700-9ed6-11eb-939c-46f73fe0aca9.png)

This probably can't happen because of the guards but if you succeed at executing the peg action on an unsupported network you get this:

![image](https://user-images.githubusercontent.com/1256409/114986145-f83efe80-9ed6-11eb-98f3-9ebdf69493fc.png)
