### PR TITLE
Fix decimal places in listing

### DIFF
--- a/ui/app/src/components/shared/utils.ts
+++ b/ui/app/src/components/shared/utils.ts
@@ -6,6 +6,7 @@ import {
   IAmount,
   IAssetAmount,
   Network,
+  toBaseUnits,
   TxHash,
 } from "ui-core";
 import { format } from "ui-core/src/utils/format";
@@ -36,7 +37,7 @@ export function formatNumber(displayNumber: string) {
 export function formatAssetAmount(value: IAssetAmount) {
   if (!value || value.equalTo("0")) return "0";
   const { amount, asset } = value;
-  return amount.greaterThan(AssetAmount(asset, "100000"))
+  return amount.greaterThan(AssetAmount(asset, toBaseUnits("100000", asset)))
     ? format(amount, asset, { mantissa: 2 })
     : format(amount, asset, { mantissa: 6 });
 }

--- a/ui/app/src/components/shared/utils.ts
+++ b/ui/app/src/components/shared/utils.ts
@@ -1,6 +1,13 @@
 import { computed, Ref } from "@vue/reactivity";
 import ColorHash from "color-hash";
-import { Asset, IAmount, IAssetAmount, Network, TxHash } from "ui-core";
+import {
+  Asset,
+  AssetAmount,
+  IAmount,
+  IAssetAmount,
+  Network,
+  TxHash,
+} from "ui-core";
 import { format } from "ui-core/src/utils/format";
 
 export function formatSymbol(symbol: string) {
@@ -29,7 +36,7 @@ export function formatNumber(displayNumber: string) {
 export function formatAssetAmount(value: IAssetAmount) {
   if (!value || value.equalTo("0")) return "0";
   const { amount, asset } = value;
-  return amount.greaterThan("100000000000000000000000")
+  return amount.greaterThan(AssetAmount(asset, "100000"))
     ? format(amount, asset, { mantissa: 2 })
     : format(amount, asset, { mantissa: 6 });
 }

--- a/ui/app/src/components/shared/utils.ts
+++ b/ui/app/src/components/shared/utils.ts
@@ -1,14 +1,6 @@
 import { computed, Ref } from "@vue/reactivity";
 import ColorHash from "color-hash";
-import {
-  Asset,
-  AssetAmount,
-  IAmount,
-  IAssetAmount,
-  Network,
-  toBaseUnits,
-  TxHash,
-} from "ui-core";
+import { Asset, IAssetAmount, Network, toBaseUnits, TxHash } from "ui-core";
 import { format } from "ui-core/src/utils/format";
 
 export function formatSymbol(symbol: string) {
@@ -37,7 +29,7 @@ export function formatNumber(displayNumber: string) {
 export function formatAssetAmount(value: IAssetAmount) {
   if (!value || value.equalTo("0")) return "0";
   const { amount, asset } = value;
-  return amount.greaterThan(AssetAmount(asset, toBaseUnits("100000", asset)))
+  return amount.greaterThan(toBaseUnits("100000", asset))
     ? format(amount, asset, { mantissa: 2 })
     : format(amount, asset, { mantissa: 6 });
 }


### PR DESCRIPTION
Closes: https://github.com/Sifchain/issues/issues/328

What was happening is that the algo wasn't taking in the asset decimals into account when calculating the pivot number.

![image](https://user-images.githubusercontent.com/1256409/115669305-76921980-a38b-11eb-9ac7-cae9c1d94133.png)


