### PR TITLE
[ChainOps] Set the address prefix.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -142,7 +142,7 @@ func init() {
 		panic(err)
 	}
 
-	DefaultNodeHome = filepath.Join(userHomeDir, ".sifenoded")
+	DefaultNodeHome = filepath.Join(userHomeDir, ".sifnoded")
 }
 
 var (

--- a/cmd/sifnoded/main.go
+++ b/cmd/sifnoded/main.go
@@ -13,6 +13,8 @@ import (
 func main() {
 	rootCmd, _ := cmd.NewRootCmd()
 
+	app.SetConfig(true)
+
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		switch e := err.(type) {
 		case server.ErrorCode:


### PR DESCRIPTION
Includes:

* Minor update to correctly set the prefix as `sif`, not `cosmos` (default).
* Fixed the spelling mistake `.sifenoded` and replaced with `.sifnoded`.