### PR TITLE
[testnet] ui/core/EthBridgeService: convert assetAmount into Base Units

### DIFF
--- a/ui/core/src/api/EthbridgeService/EthbridgeService.ts
+++ b/ui/core/src/api/EthbridgeService/EthbridgeService.ts
@@ -12,7 +12,6 @@ import { SifUnSignedClient } from "../utils/SifClient";
 import { parseTxFailure } from "./parseTxFailure";
 import { Contract } from "web3-eth-contract";
 import JSBI from "jsbi";
-import { toBaseUnits } from "../../utils/decimalShift";
 
 // TODO: Do we break this service out to ethbridge and cosmos?
 
@@ -135,11 +134,8 @@ export default function createEthbridgeService({
         value: 0,
         gas: 100000,
       };
-      // NOTE - Would be good to move toBaseUnits into AssetAmount
-      const amountInBaseUnits = toBaseUnits(
-        assetAmount.amount.toString(),
-        assetAmount.asset,
-      );
+      const amountInBaseUnits = assetAmount.toBaseUnitsAmount();
+
       // TODO - give interface option to approve unlimited spend via web3.utils.toTwosComplement(-1);
       // NOTE - We may want to move this out into its own separate function.
       // Although I couldn't think of a situation we'd call allowance separately from approve

--- a/ui/core/src/api/EthbridgeService/EthbridgeService.ts
+++ b/ui/core/src/api/EthbridgeService/EthbridgeService.ts
@@ -134,7 +134,10 @@ export default function createEthbridgeService({
         value: 0,
         gas: 100000,
       };
-      const amountInBaseUnits = assetAmount.toBaseUnitsAmount();
+      const amountInBaseUnits = assetAmount
+        .toBaseUnitsAmount()
+        .toBigInt()
+        .toString();
 
       // TODO - give interface option to approve unlimited spend via web3.utils.toTwosComplement(-1);
       // NOTE - We may want to move this out into its own separate function.

--- a/ui/core/src/api/EthbridgeService/EthbridgeService.ts
+++ b/ui/core/src/api/EthbridgeService/EthbridgeService.ts
@@ -134,10 +134,7 @@ export default function createEthbridgeService({
         value: 0,
         gas: 100000,
       };
-      const amountInBaseUnits = assetAmount
-        .toBaseUnitsAmount()
-        .toBigInt()
-        .toString();
+      const amountInBaseUnits = assetAmount.toBaseUnitsAmount();
 
       // TODO - give interface option to approve unlimited spend via web3.utils.toTwosComplement(-1);
       // NOTE - We may want to move this out into its own separate function.
@@ -145,12 +142,7 @@ export default function createEthbridgeService({
       const hasAlreadyApprovedSpend = await tokenContract.methods
         .allowance(account, bridgebankContractAddress)
         .call();
-      if (
-        JSBI.lessThanOrEqual(
-          JSBI.BigInt(amountInBaseUnits),
-          JSBI.BigInt(hasAlreadyApprovedSpend),
-        )
-      ) {
+      if (amountInBaseUnits.lessThanOrEqual(hasAlreadyApprovedSpend)) {
         // dont request approve again
         console.log(
           "approveBridgeBankSpend: spend already approved",
@@ -160,7 +152,10 @@ export default function createEthbridgeService({
       }
 
       const res = await tokenContract.methods
-        .approve(bridgebankContractAddress, amountInBaseUnits)
+        .approve(
+          bridgebankContractAddress,
+          amountInBaseUnits.toBigInt().toString(),
+        )
         .send(sendArgs);
       console.log("approveBridgeBankSpend:", res);
       return res;

--- a/ui/core/src/entities/AssetAmount.test.ts
+++ b/ui/core/src/entities/AssetAmount.test.ts
@@ -46,6 +46,12 @@ describe("AssetAmount", () => {
     expect(AssetAmount("eth", "12345678").toString()).toBe("12345678 ETH");
   });
 
+  test("#toBaseUnitsAmount", () => {
+    expect(AssetAmount("eth", "1234.5678").toBaseUnitsAmount()).toBe(
+      "1234567800000000000000",
+    );
+  });
+
   test("#add", () => {
     expect(
       AssetAmount("eth", "1000")

--- a/ui/core/src/entities/AssetAmount.test.ts
+++ b/ui/core/src/entities/AssetAmount.test.ts
@@ -47,9 +47,9 @@ describe("AssetAmount", () => {
   });
 
   test("#toBaseUnitsAmount", () => {
-    expect(AssetAmount("eth", "1234.5678").toBaseUnitsAmount()).toBe(
-      "1234567800000000000000",
-    );
+    expect(
+      AssetAmount("eth", "1234.5678").toBaseUnitsAmount().toBigInt().toString(),
+    ).toBe("1234567800000000000000");
   });
 
   test("#add", () => {

--- a/ui/core/src/entities/AssetAmount.ts
+++ b/ui/core/src/entities/AssetAmount.ts
@@ -11,7 +11,7 @@ export type IAssetAmount = Readonly<IAsset> & {
   // for use by display lib and in testing
   toBigInt(): JSBI;
   toString(detailed?: boolean): string;
-  toBaseUnitsAmount(): string;
+  toBaseUnitsAmount(): IAmount;
 
   // for use elsewhere
   add(other: IAmount | string): IAmount;
@@ -76,9 +76,7 @@ export function AssetAmount(
 
     toBaseUnitsAmount() {
       // NOTE - We may want to consider default returning a BigInt or Amount from toBaseUnits()
-      return Amount(toBaseUnits(_amount.toString(), _asset))
-        .toBigInt()
-        .toString();
+      return Amount(toBaseUnits(_amount.toString(), _asset));
     },
 
     toBigInt() {

--- a/ui/core/src/entities/AssetAmount.ts
+++ b/ui/core/src/entities/AssetAmount.ts
@@ -1,6 +1,8 @@
 import { IAmount, Amount, _ExposeInternal } from "./Amount";
 import { IAsset, Asset } from "./Asset";
 import { IFraction } from "./fraction/Fraction";
+import { toBaseUnits } from "../utils/decimalShift";
+
 import JSBI from "jsbi";
 
 export type IAssetAmount = Readonly<IAsset> & {
@@ -9,6 +11,7 @@ export type IAssetAmount = Readonly<IAsset> & {
   // for use by display lib and in testing
   toBigInt(): JSBI;
   toString(detailed?: boolean): string;
+  toBaseUnitsAmount(): string;
 
   // for use elsewhere
   add(other: IAmount | string): IAmount;
@@ -69,6 +72,13 @@ export function AssetAmount(
 
     get label() {
       return _asset.label;
+    },
+
+    toBaseUnitsAmount() {
+      // NOTE - We may want to consider default returning a BigInt or Amount from toBaseUnits()
+      return Amount(toBaseUnits(_amount.toString(), _asset))
+        .toBigInt()
+        .toString();
     },
 
     toBigInt() {


### PR DESCRIPTION
Fixes issue where `tokenContract.methods.approve()` was not receiving token amount in baseUnits. Also updated `allowance()` logic to use baseUnits.