### PR TITLE
[ui] Fix approval baseunits bug

### DIFF
--- a/ui/app/src/views/PegAssetPage.vue
+++ b/ui/app/src/views/PegAssetPage.vue
@@ -95,15 +95,13 @@ export default defineComponent({
 
     async function handlePegRequested() {
       const asset = Asset.get(symbol.value);
+      const assetAmount = AssetAmount(asset, toBaseUnits(amount.value, asset));
 
       if (asset.symbol !== "eth") {
         // if not eth you need to approve spend before peg
         transactionState.value = "approving";
         try {
-          await actions.peg.approve(
-            store.wallet.eth.address,
-            AssetAmount(asset, amount.value),
-          );
+          await actions.peg.approve(store.wallet.eth.address, assetAmount);
         } catch (err) {
           return (transactionState.value = "rejected");
         }
@@ -111,9 +109,7 @@ export default defineComponent({
 
       transactionState.value = "signing";
 
-      const tx = await actions.peg.peg(
-        AssetAmount(asset, toBaseUnits(amount.value, asset)),
-      );
+      const tx = await actions.peg.peg(assetAmount);
 
       transactionHash.value = tx.hash;
       transactionState.value = toConfirmState(tx.state); // TODO: align states

--- a/ui/core/src/entities/AssetAmount.test.ts
+++ b/ui/core/src/entities/AssetAmount.test.ts
@@ -46,10 +46,13 @@ describe("AssetAmount", () => {
     expect(AssetAmount("eth", "12345678").toString()).toBe("12345678 ETH");
   });
 
-  test("#toBaseUnitsAmount", () => {
+  test("#toDerived", () => {
     expect(
-      AssetAmount("eth", "1234.5678").toBaseUnitsAmount().toBigInt().toString(),
-    ).toBe("1234567800000000000000");
+      AssetAmount("eth", "1000000000000000000")
+        .toDerived()
+        .toBigInt()
+        .toString(),
+    ).toBe("1");
   });
 
   test("#add", () => {

--- a/ui/core/src/entities/AssetAmount.ts
+++ b/ui/core/src/entities/AssetAmount.ts
@@ -1,19 +1,55 @@
 import { IAmount, Amount, _ExposeInternal } from "./Amount";
 import { IAsset, Asset } from "./Asset";
 import { IFraction } from "./fraction/Fraction";
-import { toBaseUnits } from "../utils/decimalShift";
+import { fromBaseUnits, toBaseUnits } from "../utils/decimalShift";
 
 import JSBI from "jsbi";
 
 export type IAssetAmount = Readonly<IAsset> & {
   readonly asset: IAsset;
   readonly amount: IAmount;
-  // for use by display lib and in testing
+
+  // COMPATABILITY OPERATORS
+  // For use by display lib and in testing
+
   toBigInt(): JSBI;
   toString(detailed?: boolean): string;
-  toBaseUnitsAmount(): IAmount;
 
-  // for use elsewhere
+  // CONVENIENCE UTILITIES
+  // Utilty operators common enough to live on this class
+
+  /**
+   * Return the derived value for the AssetAmount based on the asset's decimals
+   * For example lets say we have one eth:
+   *
+   * AssetAmount("eth", "100000000000000000").toDerived().equalTo(Amount("1")); // true
+   * AssetAmount("usdc", "1000000").toDerived().equalTo(Amount("1")); // true
+   *
+   * All Math operators on AssetAmounts work on BaseUnits and return Amount objects. We have explored
+   * creating a scheme for allowing mathematical operations on AssetAmounts but it is not clear as to
+   * how to combine assets and which asset gets precedence. These rules would need to be internalized
+   * by the team which may not be intuitive. Also performing mathematical operations on differing currencies
+   * doesn't make conceptual sense.
+   *
+   *   Eg. What is 1 USDC x 1 ETH?
+   *       - is it a value in ETH?
+   *       - is it a value in USDC?
+   *       - Mathematically it would be an ETHUSDC but we have no concept of this in our systems nor do we need one
+   *
+   * Instead when mixing AssetAmounts it is recommended to first extract the derived amounts and perform calculations on those
+   *
+   *   Eg.
+   *   const ethAmount = oneEth.toDerived();
+   *   const usdcAmount = oneUsdc.toDerived();
+   *   const newAmount = ethAmount.multiply(usdcAmount);
+   *   const newUsdcAmount = AssetAmount('usdc', newAmount);
+   *
+   * @returns IAmount
+   */
+  toDerived(): IAmount;
+
+  // MATH OPERATORS
+
   add(other: IAmount | string): IAmount;
   divide(other: IAmount | string): IAmount;
   equalTo(other: IAmount | string): boolean;
@@ -74,9 +110,8 @@ export function AssetAmount(
       return _asset.label;
     },
 
-    toBaseUnitsAmount() {
-      // NOTE - We may want to consider default returning a BigInt or Amount from toBaseUnits()
-      return Amount(toBaseUnits(_amount.toString(), _asset));
+    toDerived() {
+      return _amount.multiply(fromBaseUnits("1", _asset));
     },
 
     toBigInt() {

--- a/ui/core/src/entities/AssetAmount.ts
+++ b/ui/core/src/entities/AssetAmount.ts
@@ -26,7 +26,7 @@ export type IAssetAmount = Readonly<IAsset> & {
    * AssetAmount("usdc", "1000000").toDerived().equalTo(Amount("1")); // true
    *
    * All Math operators on AssetAmounts work on BaseUnits and return Amount objects. We have explored
-   * creating a scheme for allowing mathematical operations on AssetAmounts but it is not clear as to
+   * creating a scheme for allowing mathematical operations to combine AssetAmounts but it is not clear as to
    * how to combine assets and which asset gets precedence. These rules would need to be internalized
    * by the team which may not be intuitive. Also performing mathematical operations on differing currencies
    * doesn't make conceptual sense.

--- a/ui/core/src/entities/AssetAmount.ts
+++ b/ui/core/src/entities/AssetAmount.ts
@@ -1,7 +1,7 @@
 import { IAmount, Amount, _ExposeInternal } from "./Amount";
 import { IAsset, Asset } from "./Asset";
 import { IFraction } from "./fraction/Fraction";
-import { fromBaseUnits, toBaseUnits } from "../utils/decimalShift";
+import { fromBaseUnits } from "../utils/decimalShift";
 
 import JSBI from "jsbi";
 

--- a/ui/core/src/hooks/addLiquidityCalculator.ts
+++ b/ui/core/src/hooks/addLiquidityCalculator.ts
@@ -23,10 +23,6 @@ export enum PoolState {
   ZERO_AMOUNTS_NEW_POOL,
 }
 
-function toDerived(assetAmount: IAssetAmount) {
-  return assetAmount.amount.multiply(fromBaseUnits("1", assetAmount.asset));
-}
-
 export function usePoolCalculator(input: {
   tokenAAmount: Ref<string>;
   tokenASymbol: Ref<string | null>;
@@ -201,8 +197,8 @@ export function usePoolCalculator(input: {
     if (!poolAmounts.value) return 0;
     const [native, external] = poolAmounts.value;
 
-    const derivedNative = toDerived(native);
-    const derivedExternal = toDerived(external);
+    const derivedNative = native.toDerived();
+    const derivedExternal = external.toDerived();
 
     return derivedExternal.divide(derivedNative);
   });
@@ -220,8 +216,8 @@ export function usePoolCalculator(input: {
     if (!poolAmounts.value) return 0;
     const [native, external] = poolAmounts.value;
 
-    const derivedNative = toDerived(native);
-    const derivedExternal = toDerived(external);
+    const derivedNative = native.toDerived();
+    const derivedExternal = external.toDerived();
 
     return derivedNative.divide(derivedExternal);
   });
@@ -245,10 +241,10 @@ export function usePoolCalculator(input: {
       return null;
 
     const [native, external] = poolAmounts.value;
-    const derivedNative = toDerived(native);
-    const derivedExternal = toDerived(external);
-    const externalAdded = toDerived(tokenAField.fieldAmount.value);
-    const nativeAdded = toDerived(tokenBField.fieldAmount.value);
+    const derivedNative = native.toDerived();
+    const derivedExternal = external.toDerived();
+    const externalAdded = tokenAField.fieldAmount.value.toDerived();
+    const nativeAdded = tokenBField.fieldAmount.value.toDerived();
 
     return derivedExternal
       .add(externalAdded)
@@ -274,10 +270,10 @@ export function usePoolCalculator(input: {
       return null;
 
     const [native, external] = poolAmounts.value;
-    const derivedNative = toDerived(native);
-    const derivedExternal = toDerived(external);
-    const externalAdded = toDerived(tokenAField.fieldAmount.value);
-    const nativeAdded = toDerived(tokenBField.fieldAmount.value);
+    const derivedNative = native.toDerived();
+    const derivedExternal = external.toDerived();
+    const externalAdded = tokenAField.fieldAmount.value.toDerived();
+    const nativeAdded = tokenBField.fieldAmount.value.toDerived();
     return derivedNative
       .add(nativeAdded)
       .divide(derivedExternal.add(externalAdded));
@@ -320,12 +316,12 @@ export function usePoolCalculator(input: {
       );
       if (input.lastFocusedTokenField.value === "A") {
         input.tokenBAmount.value = format(
-          toDerived(assetAmountA).multiply(bPerARatio.value || "0"),
+          assetAmountA.toDerived().multiply(bPerARatio.value || "0"),
           { mantissa: 5 },
         );
       } else if (input.lastFocusedTokenField.value === "B") {
         input.tokenAAmount.value = format(
-          toDerived(assetAmountB).multiply(aPerBRatio.value || "0"),
+          assetAmountB.toDerived().multiply(aPerBRatio.value || "0"),
           { mantissa: 5 },
         );
       }

--- a/ui/e2e/ethereum.js
+++ b/ui/e2e/ethereum.js
@@ -11,5 +11,4 @@ export async function getEthBalance(address) {
 
 export async function advanceEthBlocks() {
   await advanceBlock(50);
-  await sleep(20000); // need to wait for events to cascade
 }

--- a/ui/e2e/index.test.js
+++ b/ui/e2e/index.test.js
@@ -25,6 +25,7 @@ const {
   connectMmAccount,
   confirmTransaction,
   confirmApproval,
+  resetAccount,
 } = require("./metamask.js");
 const { importKeplrAccount, connectKeplrAccount } = require("./keplr");
 
@@ -85,6 +86,10 @@ describe("connect to page", () => {
     await connectKeplrAccount(dexPage, browserContext);
 
     await connectMmAccount(dexPage, browserContext, MM_CONFIG.id);
+  });
+
+  afterEach(async () => {
+    await resetAccount(browserContext, MM_CONFIG.id);
   });
 
   afterAll(async () => {

--- a/ui/e2e/index.test.js
+++ b/ui/e2e/index.test.js
@@ -69,11 +69,12 @@ beforeAll(async () => {
     "chrome-extension://dmkamcknogkgcdfhhbddcghachkejeap/popup.html#/register",
   );
   await importKeplrAccount(keplrPage, KEPLR_CONFIG.options);
+  await keplrPage.close();
 
   // goto dex page
   dexPage = await browserContext.newPage();
   dexPage.setDefaultTimeout(60000);
-  dexPage.waitForTimeout(1000); // wait a second before keplr is finished being setup
+  dexPage.waitForTimeout(4000); // wait a second before keplr is finished being setup
 
   await dexPage.goto(DEX_TARGET, { waitUntil: "domcontentloaded" });
 

--- a/ui/e2e/index.test.js
+++ b/ui/e2e/index.test.js
@@ -136,7 +136,7 @@ describe("connect to page", () => {
       waitUntil: "domcontentloaded",
     });
 
-    const cEthBalance = await getSifchainBalances(
+    const cBalance = await getSifchainBalances(
       keplrConfig.sifApiUrl,
       KEPLR_CONFIG.options.address,
       "cusdc",
@@ -166,7 +166,7 @@ describe("connect to page", () => {
       "[data-handle='cusdc-row-amount']",
     );
 
-    const expected = (Number(cEthBalance) + Number(pegAmount)).toFixed(6);
+    const expected = (Number(cBalance) + Number(pegAmount)).toFixed(6);
 
     expect(rowAmount.trim()).toBe(expected);
   });

--- a/ui/e2e/index.test.js
+++ b/ui/e2e/index.test.js
@@ -20,13 +20,7 @@ const { DEX_TARGET, MM_CONFIG, KEPLR_CONFIG } = require("./config.js");
 const keplrConfig = require("../core/src/config.localnet.json");
 
 // extension
-const {
-  MetaMask,
-  connectMmAccount,
-  confirmTransaction,
-  confirmApproval,
-  resetAccount,
-} = require("./metamask.js");
+const { MetaMask, connectMmAccount } = require("./metamask.js");
 const { importKeplrAccount, connectKeplrAccount } = require("./keplr");
 
 // services
@@ -44,436 +38,452 @@ let dexPage;
 
 useStack("every-test");
 
-describe("connect to page", () => {
-  beforeAll(async () => {
-    // extract extension zips
-    await extractExtensionPackages();
-    const pathToKeplrExtension = path.join(__dirname, KEPLR_CONFIG.path);
-    const pathToMmExtension = path.join(__dirname, MM_CONFIG.path);
-    const userDataDir = path.join(__dirname, "./playwright");
-    // need to rm userDataDir or else will store extension state
-    if (fs.existsSync(userDataDir)) {
-      fs.rmdirSync(userDataDir, { recursive: true });
-    }
+beforeAll(async () => {
+  // extract extension zips
+  await extractExtensionPackages();
+  const pathToKeplrExtension = path.join(__dirname, KEPLR_CONFIG.path);
+  const pathToMmExtension = path.join(__dirname, MM_CONFIG.path);
+  const userDataDir = path.join(__dirname, "./playwright");
+  // need to rm userDataDir or else will store extension state
+  if (fs.existsSync(userDataDir)) {
+    fs.rmdirSync(userDataDir, { recursive: true });
+  }
 
-    browserContext = await chromium.launchPersistentContext(userDataDir, {
-      // headless required with extensions. xvfb used for ci/cd
-      headless: false,
-      args: [
-        `--disable-extensions-except=${pathToKeplrExtension},${pathToMmExtension}`,
-        `--load-extension=${pathToKeplrExtension},${pathToMmExtension}`,
-      ],
-      // devtools: true,
-    });
-
-    // setup metamask
-    const MM = new MetaMask(browserContext, MM_CONFIG);
-    await MM.setup(browserContext);
-
-    // setup keplr account
-    const keplrPage = await browserContext.newPage();
-    await keplrPage.goto(
-      "chrome-extension://dmkamcknogkgcdfhhbddcghachkejeap/popup.html#/register",
-    );
-    await importKeplrAccount(keplrPage, KEPLR_CONFIG.options);
-
-    // goto dex page
-    dexPage = await browserContext.newPage();
-    dexPage.setDefaultTimeout(60000);
-
-    await dexPage.goto(DEX_TARGET, { waitUntil: "domcontentloaded" });
-
-    await connectKeplrAccount(dexPage, browserContext);
-
-    await connectMmAccount(dexPage, browserContext, MM_CONFIG.id);
+  browserContext = await chromium.launchPersistentContext(userDataDir, {
+    // headless required with extensions. xvfb used for ci/cd
+    headless: false,
+    args: [
+      `--disable-extensions-except=${pathToKeplrExtension},${pathToMmExtension}`,
+      `--load-extension=${pathToKeplrExtension},${pathToMmExtension}`,
+    ],
+    // devtools: true,
   });
 
-  afterEach(async () => {
-    await resetAccount(browserContext, MM_CONFIG.id);
-  });
+  // setup metamask
+  const MM = new MetaMask(browserContext, MM_CONFIG);
+  await MM.setup(browserContext);
 
-  afterAll(async () => {
-    browserContext.close();
-  });
+  // setup keplr account
+  const keplrPage = await browserContext.newPage();
+  await keplrPage.goto(
+    "chrome-extension://dmkamcknogkgcdfhhbddcghachkejeap/popup.html#/register",
+  );
+  await importKeplrAccount(keplrPage, KEPLR_CONFIG.options);
 
-  it("pegs ether", async () => {
-    // Navigate to peg page
-    await dexPage.goto(DEX_TARGET, {
+  // goto dex page
+  dexPage = await browserContext.newPage();
+  dexPage.setDefaultTimeout(60000);
+  dexPage.waitForTimeout(1000); // wait a second before keplr is finished being setup
+
+  await dexPage.goto(DEX_TARGET, { waitUntil: "domcontentloaded" });
+
+  // Keplr will automatically connect and cause the add chain popup to come up
+  await connectKeplrAccount(dexPage, browserContext);
+
+  await connectMmAccount(dexPage, browserContext, MM_CONFIG.id);
+});
+
+afterAll(async () => {
+  browserContext.close();
+});
+
+beforeEach(async () => {
+  const page = await browserContext.newPage();
+
+  await page.goto(
+    `chrome-extension://${MM_CONFIG.id}/home.html#settings/advanced`,
+    {
       waitUntil: "domcontentloaded",
-    });
+    },
+  );
+  await page.waitForTimeout(1000);
+  await page.click('[data-testid="advanced-setting-reset-account"] button');
+  await page.waitForTimeout(1000);
+  await page.click('.modal-container button:has-text("Reset")');
+  await page.close();
+});
 
-    const cEthBalance = await getSifchainBalances(
-      keplrConfig.sifApiUrl,
-      KEPLR_CONFIG.options.address,
-      "ceth",
-    );
-
-    const pegAmount = "1";
-
-    await dexPage.click("[data-handle='external-tab']");
-    await dexPage.click("[data-handle='peg-eth']");
-    await dexPage.click('[data-handle="peg-input"]');
-    await dexPage.fill('[data-handle="peg-input"]', pegAmount);
-    await dexPage.click('button:has-text("Peg")');
-    await dexPage.click('button:has-text("Confirm Peg")');
-
-    await confirmTransaction(dexPage, browserContext, pegAmount, MM_CONFIG.id);
-    // move chain forward
-    await advanceEthBlocks(52);
-
-    const rowAmount = await dexPage.innerText(
-      "[data-handle='ceth-row-amount']",
-    );
-
-    const expected = (Number(cEthBalance) + Number(pegAmount)).toFixed(6);
-
-    expect(rowAmount.trim()).toBe(expected);
+it("pegs ether", async () => {
+  // Navigate to peg page
+  await dexPage.goto(DEX_TARGET, {
+    waitUntil: "domcontentloaded",
   });
 
-  it("pegs tokens", async () => {
-    // Navigate to peg page
-    await dexPage.goto(DEX_TARGET, {
-      waitUntil: "domcontentloaded",
-    });
+  const cEthBalance = await getSifchainBalances(
+    keplrConfig.sifApiUrl,
+    KEPLR_CONFIG.options.address,
+    "ceth",
+  );
 
-    const cBalance = await getSifchainBalances(
-      keplrConfig.sifApiUrl,
-      KEPLR_CONFIG.options.address,
-      "cusdc",
-    );
+  const pegAmount = "1";
 
-    const pegAmount = "1";
+  await dexPage.click("[data-handle='external-tab']");
+  await dexPage.click("[data-handle='peg-eth']");
+  await dexPage.click('[data-handle="peg-input"]');
+  await dexPage.fill('[data-handle="peg-input"]', pegAmount);
+  await dexPage.click('button:has-text("Peg")');
 
-    await dexPage.click("[data-handle='external-tab']");
-    await dexPage.click("[data-handle='peg-usdc']");
-    await dexPage.click('[data-handle="peg-input"]');
-    await dexPage.fill('[data-handle="peg-input"]', pegAmount);
-    await dexPage.click('button:has-text("Peg")');
-    await dexPage.click('button:has-text("Confirm Peg")');
+  const [confirmPopup] = await Promise.all([
+    browserContext.waitForEvent("page"),
+    dexPage.click('button:has-text("Confirm Peg")'),
+  ]);
 
-    await confirmApproval(
-      dexPage,
-      browserContext,
-      pegAmount + " usdc",
-      MM_CONFIG.id,
-    );
+  await Promise.all([
+    confirmPopup.waitForEvent("close"),
+    confirmPopup.click('button:has-text("Confirm")'),
+  ]);
 
-    await confirmTransaction(dexPage, browserContext, pegAmount, MM_CONFIG.id);
-    // move chain forward
-    await advanceEthBlocks(52);
+  await dexPage.click("text=×");
 
-    const rowAmount = await dexPage.innerText(
-      "[data-handle='cusdc-row-amount']",
-    );
+  // move chain forward
+  await advanceEthBlocks(52);
 
-    const expected = (Number(cBalance) + Number(pegAmount)).toFixed(6);
+  await dexPage.waitForSelector("text=has succeded");
 
-    expect(rowAmount.trim()).toBe(expected);
+  const rowAmount = await dexPage.innerText("[data-handle='ceth-row-amount']");
+
+  const expected = (Number(cEthBalance) + Number(pegAmount)).toFixed(6);
+
+  expect(rowAmount.trim()).toBe(expected);
+});
+
+it("pegs tokens", async () => {
+  // Navigate to peg page
+  await dexPage.goto(DEX_TARGET, {
+    waitUntil: "domcontentloaded",
   });
 
-  it("swaps", async () => {
-    // Navigate to swap page
-    await dexPage.goto(DEX_TARGET, {
-      waitUntil: "domcontentloaded",
-    });
+  const cBalance = await getSifchainBalances(
+    keplrConfig.sifApiUrl,
+    KEPLR_CONFIG.options.address,
+    "cusdc",
+  );
 
-    await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
+  const pegAmount = "1";
 
-    await dexPage.click("[data-handle='swap-page-button']");
+  await dexPage.click("[data-handle='external-tab']");
+  await dexPage.click("[data-handle='peg-usdc']");
+  await dexPage.click('[data-handle="peg-input"]');
+  await dexPage.fill('[data-handle="peg-input"]', pegAmount);
+  await dexPage.click('button:has-text("Peg")');
 
-    await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
+  const [approveSpendPopup] = await Promise.all([
+    browserContext.waitForEvent("page"),
+    dexPage.click('button:has-text("Confirm Peg")'),
+  ]);
 
-    // Get values of token A and token B in account
-    // Select Token A
-    await dexPage.click("[data-handle='token-a-select-button']");
-    await dexPage.click("[data-handle='cusdc-select-button']");
-    // Select Token B
-    await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
-    await dexPage.click("[data-handle='token-b-select-button']");
-    await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
-    await dexPage.click("[data-handle='rowan-select-button']");
-    // Input amount A
-    await dexPage.click('[data-handle="token-a-input"]');
-    await dexPage.fill('[data-handle="token-a-input"]', "100");
+  await approveSpendPopup.click("text=View full transaction details");
+  await expect(approveSpendPopup).toHaveText(pegAmount + " usdc");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
-      "99.99800003",
-    );
+  const [confirmPopup] = await Promise.all([
+    browserContext.waitForEvent("page"),
+    approveSpendPopup.click('button:has-text("Confirm")'),
+  ]);
 
-    // Check expected output (XXX: hmmm - might have to pull in formulae from core??)
+  await Promise.all([
+    confirmPopup.waitForEvent("close"),
+    confirmPopup.click('button:has-text("Confirm")'),
+  ]);
 
-    // Input amount B
-    await dexPage.click('[data-handle="token-b-input"]');
-    await dexPage.fill('[data-handle="token-b-input"]', "100");
+  await dexPage.click("text=×");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
-      "100.00200005",
-    );
+  await advanceEthBlocks(52);
 
-    // Click max
-    await dexPage.click("[data-handle='token-a-max-button']");
+  await dexPage.waitForSelector("text=has succeded");
 
-    // Check expected estimated values
-    expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
-      "10000.0", // TODO: trim mantissa
-    );
-    expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
-      "9980.0299600499",
-    );
-    expect(
-      await dexPage.innerText("[data-handle='details-price-message']"),
-    ).toBe("0.998003 ROWAN per cUSDC");
-    expect(
-      await dexPage.innerText("[data-handle='details-minimum-received']"),
-    ).toBe("9880.229660 ROWAN");
-    expect(
-      await dexPage.innerText("[data-handle='details-price-impact']"),
-    ).toBe("0.10%");
-    expect(
-      await dexPage.innerText("[data-handle='details-liquidity-provider-fee']"),
-    ).toBe("9.9800 ROWAN");
+  const rowAmount = await dexPage.innerText("[data-handle='cusdc-row-amount']");
 
-    // Input Amount A
-    await dexPage.click('[data-handle="token-a-input"]');
-    await dexPage.fill('[data-handle="token-a-input"]', "50");
+  const expected = (Number(cBalance) + Number(pegAmount)).toFixed(6);
 
-    expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
-      "49.9995000037",
-    );
-    expect(
-      await dexPage.innerText("[data-handle='details-price-message']"),
-    ).toBe("0.999990 ROWAN per cUSDC");
-    expect(
-      await dexPage.innerText("[data-handle='details-minimum-received']"),
-    ).toBe("49.499505 ROWAN");
-    expect(
-      await dexPage.innerText("[data-handle='details-price-impact']"),
-    ).toBe("< 0.01%");
-    expect(
-      await dexPage.innerText("[data-handle='details-liquidity-provider-fee']"),
-    ).toBe("0.00025 ROWAN");
+  expect(rowAmount.trim()).toBe(expected);
+});
 
-    // Click Swap Button
-    await dexPage.click('button:has-text("Swap")');
-
-    // Confirm dialog shows the expected values
-    expect(
-      await dexPage.innerText(
-        "[data-handle='confirm-swap-modal'] [data-handle='details-price-message']",
-      ),
-    ).toBe("0.999990 ROWAN per cUSDC");
-    expect(
-      await dexPage.innerText(
-        "[data-handle='confirm-swap-modal'] [data-handle='details-minimum-received']",
-      ),
-    ).toBe("49.499505 ROWAN");
-    expect(
-      await dexPage.innerText(
-        "[data-handle='confirm-swap-modal'] [data-handle='details-price-impact']",
-      ),
-    ).toBe("< 0.01%");
-    expect(
-      await dexPage.innerText(
-        "[data-handle='confirm-swap-modal'] [data-handle='details-liquidity-provider-fee']",
-      ),
-    ).toBe("0.00025 ROWAN");
-
-    await dexPage.click('button:has-text("Confirm Swap")');
-
-    // Confirm transactioni popup
-
-    const keplrPage = await getExtensionPage(browserContext, KEPLR_CONFIG.id);
-
-    await keplrPage.waitForLoadState();
-    await keplrPage.click("text=Approve");
-    await keplrPage.waitForLoadState();
-    await dexPage.waitForTimeout(10000); // wait for blockchain to update...
-
-    // Wait for balances to be the amounts expected
-    expect(await dexPage.innerText('[data-handle="swap-message"]')).toBe(
-      "Swapped 50 cusdc for 49.9995000037 rowan",
-    );
-
-    await dexPage.click("[data-handle='modal-view-close']");
-
-    expect(await dexPage.innerText('[data-handle="cusdc-balance-label"]')).toBe(
-      "Balance: 9,950.00 cUSDC",
-    );
-
-    expect(await dexPage.innerText('[data-handle="rowan-balance-label"]')).toBe(
-      "Balance: 10,050.00 ROWAN",
-    );
+it("swaps", async () => {
+  // Navigate to swap page
+  await dexPage.goto(DEX_TARGET, {
+    waitUntil: "domcontentloaded",
   });
 
-  it("adds liquidity", async () => {
-    // Navigate to swap page
-    await dexPage.goto(DEX_TARGET, {
-      waitUntil: "domcontentloaded",
-    });
-    // Click pool page
-    await dexPage.click('[data-handle="pool-page-button"]');
+  await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
 
-    // Click add liquidity button
-    await dexPage.click('[data-handle="add-liquidity-button"]');
+  await dexPage.click("[data-handle='swap-page-button']");
 
-    // Select ceth
-    await dexPage.click("[data-handle='token-a-select-button']");
-    await dexPage.click("[data-handle='ceth-select-button']");
+  await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
 
-    await dexPage.click('[data-handle="token-a-input"]');
-    await dexPage.fill('[data-handle="token-a-input"]', "10");
+  // Get values of token A and token B in account
+  // Select Token A
+  await dexPage.click("[data-handle='token-a-select-button']");
+  await dexPage.click("[data-handle='cusdc-select-button']");
+  // Select Token B
+  await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
+  await dexPage.click("[data-handle='token-b-select-button']");
+  await dexPage.waitForTimeout(1000); // slowing down to avoid tokens not updating
+  await dexPage.click("[data-handle='rowan-select-button']");
+  // Input amount A
+  await dexPage.click('[data-handle="token-a-input"]');
+  await dexPage.fill('[data-handle="token-a-input"]', "100");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
-      "12048.19277",
-    );
+  expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
+    "99.99800003",
+  );
 
-    await dexPage.click('[data-handle="token-b-input"]');
-    await dexPage.fill('[data-handle="token-b-input"]', "10000");
+  // Check expected output (XXX: hmmm - might have to pull in formulae from core??)
 
-    await dexPage.click('[data-handle="token-a-input"]');
+  // Input amount B
+  await dexPage.click('[data-handle="token-b-input"]');
+  await dexPage.fill('[data-handle="token-b-input"]', "100");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
-      "8.30000",
-    );
+  expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
+    "100.00200005",
+  );
 
-    await dexPage.click('[data-handle="token-a-max-button"]');
+  // Click max
+  await dexPage.click("[data-handle='token-a-max-button']");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
-      "100.000000000000000000",
-    );
+  // Check expected estimated values
+  expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
+    "10000.0", // TODO: trim mantissa
+  );
+  expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
+    "9980.0299600499",
+  );
+  expect(await dexPage.innerText("[data-handle='details-price-message']")).toBe(
+    "0.998003 ROWAN per cUSDC",
+  );
+  expect(
+    await dexPage.innerText("[data-handle='details-minimum-received']"),
+  ).toBe("9880.229660 ROWAN");
+  expect(await dexPage.innerText("[data-handle='details-price-impact']")).toBe(
+    "0.10%",
+  );
+  expect(
+    await dexPage.innerText("[data-handle='details-liquidity-provider-fee']"),
+  ).toBe("9.9800 ROWAN");
 
-    await dexPage.click('[data-handle="token-b-input"]');
+  // Input Amount A
+  await dexPage.click('[data-handle="token-a-input"]');
+  await dexPage.fill('[data-handle="token-a-input"]', "50");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
-      "120481.92771",
-    );
+  expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
+    "49.9995000037",
+  );
+  expect(await dexPage.innerText("[data-handle='details-price-message']")).toBe(
+    "0.999990 ROWAN per cUSDC",
+  );
+  expect(
+    await dexPage.innerText("[data-handle='details-minimum-received']"),
+  ).toBe("49.499505 ROWAN");
+  expect(await dexPage.innerText("[data-handle='details-price-impact']")).toBe(
+    "< 0.01%",
+  );
+  expect(
+    await dexPage.innerText("[data-handle='details-liquidity-provider-fee']"),
+  ).toBe("0.00025 ROWAN");
 
-    expect(
-      (await dexPage.innerText('[data-handle="actions-go"]')).toUpperCase(),
-    ).toBe("INSUFFICIENT FUNDS");
+  // Click Swap Button
+  await dexPage.click('button:has-text("Swap")');
 
-    await dexPage.click('[data-handle="token-a-max-button"]');
-    await dexPage.fill('[data-handle="token-a-input"]', "5");
+  // Confirm dialog shows the expected values
+  expect(
+    await dexPage.innerText(
+      "[data-handle='confirm-swap-modal'] [data-handle='details-price-message']",
+    ),
+  ).toBe("0.999990 ROWAN per cUSDC");
+  expect(
+    await dexPage.innerText(
+      "[data-handle='confirm-swap-modal'] [data-handle='details-minimum-received']",
+    ),
+  ).toBe("49.499505 ROWAN");
+  expect(
+    await dexPage.innerText(
+      "[data-handle='confirm-swap-modal'] [data-handle='details-price-impact']",
+    ),
+  ).toBe("< 0.01%");
+  expect(
+    await dexPage.innerText(
+      "[data-handle='confirm-swap-modal'] [data-handle='details-liquidity-provider-fee']",
+    ),
+  ).toBe("0.00025 ROWAN");
 
-    expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
-      "6024.09639",
-    );
+  await dexPage.click('button:has-text("Confirm Swap")');
 
-    expect(
-      (await dexPage.innerText('[data-handle="actions-go"]')).toUpperCase(),
-    ).toBe("ADD LIQUIDITY");
+  // Confirm transactioni popup
 
-    expect(
-      await dexPage.innerText('[data-handle="pool-prices-forward-number"]'),
-    ).toBe("0.000830");
-    expect(
-      await dexPage.innerText('[data-handle="pool-prices-forward-symbols"]'),
-    ).toBe("cETH per ROWAN");
+  const keplrPage = await getExtensionPage(browserContext, KEPLR_CONFIG.id);
 
-    expect(
-      await dexPage.innerText('[data-handle="pool-prices-backward-number"]'),
-    ).toBe("1204.819277");
-    expect(
-      await dexPage.innerText('[data-handle="pool-prices-backward-symbols"]'),
-    ).toBe("ROWAN per cETH");
+  await keplrPage.waitForLoadState();
+  await keplrPage.click("text=Approve");
+  await keplrPage.waitForLoadState();
+  await dexPage.waitForTimeout(10000); // wait for blockchain to update...
 
-    expect(
-      await dexPage.innerText('[data-handle="pool-estimates-forwards-number"]'),
-    ).toBe("0.000830");
-    expect(
-      await dexPage.innerText(
-        '[data-handle="pool-estimates-forwards-symbols"]',
-      ),
-    ).toBe("CETH per ROWAN"); // <-- this is a bug TODO: cETH
+  // Wait for balances to be the amounts expected
+  expect(await dexPage.innerText('[data-handle="swap-message"]')).toBe(
+    "Swapped 50 cusdc for 49.9995000037 rowan",
+  );
 
-    expect(
-      await dexPage.innerText(
-        '[data-handle="pool-estimates-backwards-number"]',
-      ),
-    ).toBe("1204.819277");
-    expect(
-      await dexPage.innerText(
-        '[data-handle="pool-estimates-backwards-symbols"]',
-      ),
-    ).toBe("ROWAN per CETH"); // <-- this is a bug TODO: cETH
-    expect(
-      await dexPage.innerText('[data-handle="pool-estimates-share-number"]'),
-    ).toBe("0.06%");
+  await dexPage.click("[data-handle='modal-view-close']");
 
-    await dexPage.click('[data-handle="actions-go"]');
+  expect(await dexPage.innerText('[data-handle="cusdc-balance-label"]')).toBe(
+    "Balance: 9,950.00 cUSDC",
+  );
 
-    expect(
-      await dexPage.innerText('[data-handle="confirmation-modal-title"]'),
-    ).toBe("You are depositing");
+  expect(await dexPage.innerText('[data-handle="rowan-balance-label"]')).toBe(
+    "Balance: 10,050.00 ROWAN",
+  );
+});
 
-    expect(
-      prepareRowText(
-        await dexPage.innerText(
-          '[data-handle="token-a-details-panel-pool-row"]',
-        ),
-      ),
-    ).toBe("cETH Deposited 5");
-
-    expect(
-      prepareRowText(
-        await dexPage.innerText(
-          '[data-handle="token-b-details-panel-pool-row"]',
-        ),
-      ),
-    ).toBe("ROWAN Deposited 6024.09639");
-
-    expect(
-      prepareRowText(
-        await dexPage.innerText('[data-handle="real-b-per-a-row"]'),
-      ),
-    ).toBe("Rates 1 cETH = 1204.81927711 ROWAN");
-    expect(
-      prepareRowText(
-        await dexPage.innerText('[data-handle="real-a-per-b-row"]'),
-      ),
-    ).toBe("1 ROWAN = 0.00083000 cETH");
-    expect(
-      prepareRowText(
-        await dexPage.innerText('[data-handle="real-share-of-pool"]'),
-      ),
-    ).toBe("Share of Pool: 0.06%"); // TODO: remove ":"
-
-    await dexPage.click("button:has-text('CONFIRM SUPPLY')");
-
-    expect(
-      await dexPage.innerText('[data-handle="confirmation-wait-message"]'),
-    ).toBe("Supplying 5 ceth and 6024.09639 rowan");
-
-    // Confirm transaction popup
-
-    const keplrPage = await getExtensionPage(browserContext, KEPLR_CONFIG.id);
-
-    await keplrPage.waitForLoadState();
-    await keplrPage.click("text=Approve");
-    await keplrPage.waitForLoadState();
-    await dexPage.waitForTimeout(10000); // wait for blockchain to update...
-
-    await dexPage.click("text=×");
-    await dexPage.click('[data-handle="ceth-rowan-pool-list-item"]');
-
-    expect(
-      prepareRowText(
-        await dexPage.innerText('[data-handle="total-pooled-ceth"]'),
-      ),
-    ).toBe("Total Pooled cETH: 8305.00000");
-
-    expect(
-      prepareRowText(
-        await dexPage.innerText('[data-handle="total-pooled-rowan"]'),
-      ),
-    ).toBe("Total Pooled ROWAN: 10006024.09639");
-
-    expect(
-      prepareRowText(
-        await dexPage.innerText('[data-handle="total-pool-share"]'),
-      ),
-    ).toBe("Your pool share: 0.0602 %");
+it("adds liquidity", async () => {
+  // Navigate to swap page
+  await dexPage.goto(DEX_TARGET, {
+    waitUntil: "domcontentloaded",
   });
+  // Click pool page
+  await dexPage.click('[data-handle="pool-page-button"]');
+
+  // Click add liquidity button
+  await dexPage.click('[data-handle="add-liquidity-button"]');
+
+  // Select ceth
+  await dexPage.click("[data-handle='token-a-select-button']");
+  await dexPage.click("[data-handle='ceth-select-button']");
+
+  await dexPage.click('[data-handle="token-a-input"]');
+  await dexPage.fill('[data-handle="token-a-input"]', "10");
+
+  expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
+    "12048.19277",
+  );
+
+  await dexPage.click('[data-handle="token-b-input"]');
+  await dexPage.fill('[data-handle="token-b-input"]', "10000");
+
+  await dexPage.click('[data-handle="token-a-input"]');
+
+  expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
+    "8.30000",
+  );
+
+  await dexPage.click('[data-handle="token-a-max-button"]');
+
+  expect(await getInputValue(dexPage, '[data-handle="token-a-input"]')).toBe(
+    "100.000000000000000000",
+  );
+
+  await dexPage.click('[data-handle="token-b-input"]');
+
+  expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
+    "120481.92771",
+  );
+
+  expect(
+    (await dexPage.innerText('[data-handle="actions-go"]')).toUpperCase(),
+  ).toBe("INSUFFICIENT FUNDS");
+
+  await dexPage.click('[data-handle="token-a-max-button"]');
+  await dexPage.fill('[data-handle="token-a-input"]', "5");
+
+  expect(await getInputValue(dexPage, '[data-handle="token-b-input"]')).toBe(
+    "6024.09639",
+  );
+
+  expect(
+    (await dexPage.innerText('[data-handle="actions-go"]')).toUpperCase(),
+  ).toBe("ADD LIQUIDITY");
+
+  expect(
+    await dexPage.innerText('[data-handle="pool-prices-forward-number"]'),
+  ).toBe("0.000830");
+  expect(
+    await dexPage.innerText('[data-handle="pool-prices-forward-symbols"]'),
+  ).toBe("cETH per ROWAN");
+
+  expect(
+    await dexPage.innerText('[data-handle="pool-prices-backward-number"]'),
+  ).toBe("1204.819277");
+  expect(
+    await dexPage.innerText('[data-handle="pool-prices-backward-symbols"]'),
+  ).toBe("ROWAN per cETH");
+
+  expect(
+    await dexPage.innerText('[data-handle="pool-estimates-forwards-number"]'),
+  ).toBe("0.000830");
+  expect(
+    await dexPage.innerText('[data-handle="pool-estimates-forwards-symbols"]'),
+  ).toBe("CETH per ROWAN"); // <-- this is a bug TODO: cETH
+
+  expect(
+    await dexPage.innerText('[data-handle="pool-estimates-backwards-number"]'),
+  ).toBe("1204.819277");
+  expect(
+    await dexPage.innerText('[data-handle="pool-estimates-backwards-symbols"]'),
+  ).toBe("ROWAN per CETH"); // <-- this is a bug TODO: cETH
+  expect(
+    await dexPage.innerText('[data-handle="pool-estimates-share-number"]'),
+  ).toBe("0.06%");
+
+  await dexPage.click('[data-handle="actions-go"]');
+
+  expect(
+    await dexPage.innerText('[data-handle="confirmation-modal-title"]'),
+  ).toBe("You are depositing");
+
+  expect(
+    prepareRowText(
+      await dexPage.innerText('[data-handle="token-a-details-panel-pool-row"]'),
+    ),
+  ).toBe("cETH Deposited 5");
+
+  expect(
+    prepareRowText(
+      await dexPage.innerText('[data-handle="token-b-details-panel-pool-row"]'),
+    ),
+  ).toBe("ROWAN Deposited 6024.09639");
+
+  expect(
+    prepareRowText(await dexPage.innerText('[data-handle="real-b-per-a-row"]')),
+  ).toBe("Rates 1 cETH = 1204.81927711 ROWAN");
+  expect(
+    prepareRowText(await dexPage.innerText('[data-handle="real-a-per-b-row"]')),
+  ).toBe("1 ROWAN = 0.00083000 cETH");
+  expect(
+    prepareRowText(
+      await dexPage.innerText('[data-handle="real-share-of-pool"]'),
+    ),
+  ).toBe("Share of Pool: 0.06%"); // TODO: remove ":"
+
+  await dexPage.click("button:has-text('CONFIRM SUPPLY')");
+
+  expect(
+    await dexPage.innerText('[data-handle="confirmation-wait-message"]'),
+  ).toBe("Supplying 5 ceth and 6024.09639 rowan");
+
+  // Confirm transaction popup
+
+  const keplrPage = await getExtensionPage(browserContext, KEPLR_CONFIG.id);
+
+  await keplrPage.waitForLoadState();
+  await keplrPage.click("text=Approve");
+  await keplrPage.waitForLoadState();
+  await dexPage.waitForTimeout(10000); // wait for blockchain to update...
+
+  await dexPage.click("text=×");
+  await dexPage.click('[data-handle="ceth-rowan-pool-list-item"]');
+
+  expect(
+    prepareRowText(
+      await dexPage.innerText('[data-handle="total-pooled-ceth"]'),
+    ),
+  ).toBe("Total Pooled cETH: 8305.00000");
+
+  expect(
+    prepareRowText(
+      await dexPage.innerText('[data-handle="total-pooled-rowan"]'),
+    ),
+  ).toBe("Total Pooled ROWAN: 10006024.09639");
+
+  expect(
+    prepareRowText(await dexPage.innerText('[data-handle="total-pool-share"]')),
+  ).toBe("Your pool share: 0.0602 %");
 });
 
 function prepareRowText(row) {

--- a/ui/e2e/keplr.js
+++ b/ui/e2e/keplr.js
@@ -13,12 +13,12 @@ export async function importKeplrAccount(page, options) {
 }
 
 export async function connectKeplrAccount(page, browserContext) {
-  const [newPage] = await Promise.all([browserContext.waitForEvent("page")]);
-  await newPage.waitForLoadState();
-  await newPage.click("text=Approve");
-  await newPage.waitForLoadState();
-
-  const [popup] = await Promise.all([browserContext.waitForEvent("page")]);
-  await popup.waitForLoadState();
+  const newPage = await browserContext.waitForEvent("page");
+  await newPage.waitForLoadState("domcontentloaded");
+  const [popup] = await Promise.all([
+    browserContext.waitForEvent("page"),
+    newPage.click("text=Approve"),
+  ]);
+  await popup.waitForLoadState("domcontentloaded");
   await popup.click("text=Approve");
 }

--- a/ui/e2e/metamask.js
+++ b/ui/e2e/metamask.js
@@ -52,8 +52,10 @@ async function addNetwork(mmPage, config) {
 
 export async function connectMmAccount(page, browserContext, extensionId) {
   await page.click("[data-handle='button-connected']");
-  await page.click("button:has-text('Connect Metamask')");
-  const mmConnectPage = await getExtensionPage(browserContext, extensionId);
+  const [mmConnectPage] = await Promise.all([
+    browserContext.waitForEvent("page"),
+    page.click("button:has-text('Connect Metamask')"),
+  ]);
   await mmConnectPage.click(
     "#app-content > div > div.main-container-wrapper > div > div.permissions-connect-choose-account > div.permissions-connect-choose-account__footer-container > div.permissions-connect-choose-account__bottom-buttons > button.button.btn-primary",
   );
@@ -62,46 +64,4 @@ export async function connectMmAccount(page, browserContext, extensionId) {
   );
   await page.click("text=×");
   return;
-}
-
-export async function confirmTransaction(
-  page,
-  browserContext,
-  amount,
-  extensionId,
-) {
-  // extension popup
-  const mmConnectPage = await getExtensionPage(browserContext, extensionId);
-  await mmConnectPage.click("text=Confirm");
-  // haven't yet figured out how to capture close popup event
-  await page.waitForTimeout(1000);
-  await page.click("text=×");
-}
-
-export async function confirmApproval(
-  page,
-  browserContext,
-  amount,
-  extensionId,
-) {
-  const mmConnectPage = await getExtensionPage(browserContext, extensionId);
-  await mmConnectPage.click("text=View full transaction details");
-  await expect(mmConnectPage).toHaveText(amount);
-  await mmConnectPage.click("text=Confirm");
-  await page.waitForTimeout(1000);
-}
-
-export async function resetAccount(browserContext, extensionId) {
-  const page = await browserContext.newPage();
-
-  await page.goto(
-    `chrome-extension://${extensionId}/home.html#settings/advanced`,
-    {
-      waitUntil: "domcontentloaded",
-    },
-  );
-  await page.waitForTimeout(1000);
-  await page.click('[data-testid="advanced-setting-reset-account"] button');
-  await page.waitForTimeout(1000);
-  await page.click('.modal-container button:has-text("Reset")');
 }

--- a/ui/e2e/metamask.js
+++ b/ui/e2e/metamask.js
@@ -51,7 +51,7 @@ async function addNetwork(mmPage, config) {
 }
 
 export async function connectMmAccount(page, browserContext, extensionId) {
-  await page.click("[data-handle='buton-connected']");
+  await page.click("[data-handle='button-connected']");
   await page.click("button:has-text('Connect Metamask')");
   const mmConnectPage = await getExtensionPage(browserContext, extensionId);
   await mmConnectPage.click(

--- a/ui/e2e/metamask.js
+++ b/ui/e2e/metamask.js
@@ -51,7 +51,7 @@ async function addNetwork(mmPage, config) {
 }
 
 export async function connectMmAccount(page, browserContext, extensionId) {
-  await page.click("[data-handle='button-connected']");
+  await page.click("[data-handle='buton-connected']");
   await page.click("button:has-text('Connect Metamask')");
   const mmConnectPage = await getExtensionPage(browserContext, extensionId);
   await mmConnectPage.click(
@@ -88,4 +88,20 @@ export async function confirmApproval(
   await mmConnectPage.click("text=View full transaction details");
   await expect(mmConnectPage).toHaveText(amount);
   await mmConnectPage.click("text=Confirm");
+  await page.waitForTimeout(1000);
+}
+
+export async function resetAccount(browserContext, extensionId) {
+  const page = await browserContext.newPage();
+
+  await page.goto(
+    `chrome-extension://${extensionId}/home.html#settings/advanced`,
+    {
+      waitUntil: "domcontentloaded",
+    },
+  );
+  await page.waitForTimeout(1000);
+  await page.click('[data-testid="advanced-setting-reset-account"] button');
+  await page.waitForTimeout(1000);
+  await page.click('.modal-container button:has-text("Reset")');
 }

--- a/ui/e2e/metamask.js
+++ b/ui/e2e/metamask.js
@@ -72,11 +72,20 @@ export async function confirmTransaction(
 ) {
   // extension popup
   const mmConnectPage = await getExtensionPage(browserContext, extensionId);
-  await mmConnectPage.click(
-    "#app-content > div > div.main-container-wrapper > div > div.confirm-page-container-content > div.page-container__footer > footer > button.button.btn-primary.page-container__footer-button",
-  );
+  await mmConnectPage.click("text=Confirm");
   // haven't yet figured out how to capture close popup event
   await page.waitForTimeout(1000);
   await page.click("text=×");
-  return;
+}
+
+export async function confirmApproval(
+  page,
+  browserContext,
+  amount,
+  extensionId,
+) {
+  const mmConnectPage = await getExtensionPage(browserContext, extensionId);
+  await mmConnectPage.click("text=View full transaction details");
+  await expect(mmConnectPage).toHaveText(amount);
+  await mmConnectPage.click("text=Confirm");
 }

--- a/ui/e2e/metamask.js
+++ b/ui/e2e/metamask.js
@@ -9,6 +9,7 @@ export class MetaMask {
     await confirmWelcomeScreen(mmPage);
     await importAccount(mmPage, this.config);
     await addNetwork(mmPage, this.config);
+    await mmPage.close();
   }
 }
 

--- a/ui/e2e/package.json
+++ b/ui/e2e/package.json
@@ -17,6 +17,7 @@
     "ts-jest": "^26.5.4"
   },
   "dependencies": {
+    "expect-playwright": "^0.3.4",
     "global": "^4.4.0",
     "isomorphic-fetch": "^3.0.0",
     "tree-kill": "^1.2.2"
@@ -24,7 +25,10 @@
   "jest": {
     "testTimeout": 1000000,
     "collectCoverage": true,
-    "bail": true
+    "bail": true,
+    "setupFilesAfterEnv": [
+      "expect-playwright"
+    ]
   },
   "scripts": {
     "test": "jest --runInBand"

--- a/ui/test/tsconfig.json
+++ b/ui/test/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "strict": true,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "types": ["node", "jest"],
+    "baseUrl": "."
+  },
+  "include": ["./*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10723,6 +10723,11 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expect-playwright@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/expect-playwright/-/expect-playwright-0.3.4.tgz#97a2eea0f4887350cf57b1f132484d14ca5bb301"
+  integrity sha512-JulhMkc5lVvpF18ImWLqviHZpo4qzT9FfpF+lP4D+U9guGUnYOCFpS/5Qk1c3zKhYHJL1JBEfiiGfcRUuzsnEg==
+
 expect@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"


### PR DESCRIPTION
Referenced by https://github.com/Sifchain/issues/issues/396

With reference to https://sifchain.slack.com/archives/G01BX71QY1F/p1619822131293500

Unfortunately [this fix](https://github.com/Sifchain/sifnode/pull/1222) solved the problem at the wrong level of abstraction missing the actual bug which was that the amount was not being converted to baseunits in the view code.

This fixes the bug in approval baseunit as well as adds an accompanying test. 

~I believe we will want to revert #1222 and merge this to the release from develop.~

This reverts #1222 and replaces it with a fix within the view.

This does not acknowledge the underlying architectural issue which is that approve should be called in the usecase not the view. 

---

Testing changes were done in order to make the test work.

To do this properly I had to add a test. I was finding that sometimes events didn't quite happen in the order we were expecting causing instabilities and using Promis.all around clicks and listening for pop ups helps. Metamask may have been caching its state between tests which can cause weirdness. I could not seem to add a beforeEach block to the current setup for some reason (likely a bug). So I restructured the tests to be outside of the describe block. This allowed beforeEach to run correctly. At the same time I ensured the tests were not using magic numbers for waiting for block confirmations and instead wait for the UI to say has succeeded.


