### PR TITLE
[ChainOps] Cryptoeconomics container resource tweaks.

### DIFF
--- a/deploy/helm/cryptoeconomics/values.yaml
+++ b/deploy/helm/cryptoeconomics/values.yaml
@@ -37,6 +37,7 @@ resources:
     cpu: 1
     memory: 8Gi
   limits:
+    memory: 16Gi
 
 autoscaling:
   enabled: false

--- a/deploy/helm/cryptoeconomics/values.yaml
+++ b/deploy/helm/cryptoeconomics/values.yaml
@@ -35,9 +35,8 @@ ingress:
 resources:
   requests:
     cpu: 1
-    memory: 2Gi
+    memory: 8Gi
   limits:
-    memory: 4Gi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Includes:

* Set a minimum of 8Gi and a max of 16Gi for the cryptoeconomics container.