### PR TITLE
Move instant stack docker container

### DIFF
--- a/ui/scripts/build-stack-backend-docker.sh
+++ b/ui/scripts/build-stack-backend-docker.sh
@@ -3,5 +3,11 @@
 
 # this is temporarily being published on rudis docker hub account - @ryarfley
 # TODO: investigate publishing on sifchain repository (possibly GH repo)
-cd .. && docker build -f ./ui/scripts/stack.Dockerfile -t ryardley/sifdevstack01:experimental1 .
-docker push ryardley/sifdevstack01:experimental1
+
+
+NOW=$(date +%s)
+IMAGE_NAME=ghcr.io/sifchain/sifnode/ui-stack:$NOW
+cd .. && docker build -f ./ui/scripts/stack.Dockerfile -t $IMAGE_NAME .
+docker push $IMAGE_NAME
+
+echo $IMAGE_NAME > ./scripts/latest

--- a/ui/scripts/build-stack-backend-docker.sh
+++ b/ui/scripts/build-stack-backend-docker.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+if  [[ $(cat ~/.docker/config.json  | jq '.auths["ghcr.io"].auth') == 'null' ]]; then
+  echo "In order to run this script and push a new container to the github registry you need to create a personal access token and use it to login to ghcr with docker"
+  echo ""
+  echo "  echo \$MY_PAT | docker login ghcr.io -u USERNAME --password-stdin"
+  echo ""
+  echo "For more information see https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry"
+  echo ""
+  echo "Create a personal access token and log into docker using the above link then try running this script again.s"
+  exit 1
+fi
 
-# this is temporarily being published on rudis docker hub account - @ryarfley
-# TODO: investigate publishing on sifchain repository (possibly GH repo)
-
+echo "Github Registry Login found."
+echo "Building new container..."
 
 NOW=$(date +%s)
 IMAGE_NAME=ghcr.io/sifchain/sifnode/ui-stack:$NOW

--- a/ui/scripts/build-stack-backend-docker.sh
+++ b/ui/scripts/build-stack-backend-docker.sh
@@ -16,7 +16,12 @@ echo "Building new container..."
 
 NOW=$(date +%s)
 IMAGE_NAME=ghcr.io/sifchain/sifnode/ui-stack:$NOW
+
+echo "New image name: $IMAGE_NAME"
+
 cd .. && docker build -f ./ui/scripts/stack.Dockerfile -t $IMAGE_NAME .
 docker push $IMAGE_NAME
 
 echo $IMAGE_NAME > ./scripts/latest
+
+echo "Commit the ./latest file to git"

--- a/ui/scripts/kill-stack-backend.sh
+++ b/ui/scripts/kill-stack-backend.sh
@@ -1,1 +1,1 @@
-docker ps -q -f name=sifdevstack01 && docker stop sifdevstack01 && docker rm -f sifdevstack01
+docker ps -q -f name=sif-ui-stack && docker stop sif-ui-stack && docker rm -f sif-ui-stack

--- a/ui/scripts/latest
+++ b/ui/scripts/latest
@@ -1,0 +1,1 @@
+ghcr.io/sifchain/sifnode/ui-stack:1620300418

--- a/ui/scripts/run-stack-backend.sh
+++ b/ui/scripts/run-stack-backend.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-
+IMAGE_NAME=$(cat ./scripts/latest)
 docker ps -q -f name=sifdevstack01 && docker stop sifdevstack01 && docker rm sifdevstack01
 
 # this runs a docker image built by the build command
 # the image temporarily will be pulled from dockerhub 
 # but at a point soon will be transferred to our GH actions repo
-docker run \
+docker run -it \
   -p 1317:1317 \
   -p 7545:7545 \
   -p 26656:26656 \
   -p 26657:26657 \
   --name sifdevstack01 \
   --platform linux/amd64 \
-  ryardley/sifdevstack01:experimental
+  $IMAGE_NAME

--- a/ui/scripts/run-stack-backend.sh
+++ b/ui/scripts/run-stack-backend.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
+
+# get latest image name from latest file
 IMAGE_NAME=$(cat ./scripts/latest)
-docker ps -q -f name=sifdevstack01 && docker stop sifdevstack01 && docker rm sifdevstack01
+
+# kill all other docker processes
+docker ps -q -f name=sif-ui-stack && docker stop sif-ui-stack && docker rm sif-ui-stack
 
 # this runs a docker image built by the build command
 # the image temporarily will be pulled from dockerhub 
@@ -10,6 +14,6 @@ docker run -it \
   -p 7545:7545 \
   -p 26656:26656 \
   -p 26657:26657 \
-  --name sifdevstack01 \
+  --name sif-ui-stack \
   --platform linux/amd64 \
   $IMAGE_NAME


### PR DESCRIPTION
This PR moves the docker image we base the instant stack on to the ghcr container registry we use for sifnode.

