### PR TITLE
Add dev container for VSCode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,4 +15,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # RUN go get -x <your-dependency-or-tool>
 
 # Install Node packages
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g ganache-cli" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g ganache-cli truffle" 2>&1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+# Install Go version 1.16
+ARG VARIANT="1.16"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# Install Node
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Set up system dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends netcat tmux
+
+# Install Go packages
+# RUN go get -x <your-dependency-or-tool>
+
+# Install Node packages
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g ganache-cli" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.15
+			"VARIANT": "1",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
A simple dev container for VSCode which includes the following: 

Programming Languages:
- Go 1.16
- Node

System Libraries: 
- tmux
- netcat

Node Libraries:
- ganache-cli

When you open VSCode the project will automatically start a container with the tools required to run some of the basic tests, if you have the Remote Containers extension installed. It's a nice workflow :) 