### PR TITLE
Backend tests frontend

### DIFF
--- a/.github/workflows/ui-stack.yml
+++ b/.github/workflows/ui-stack.yml
@@ -1,4 +1,4 @@
-name: Build ui-stack backend
+name: Build ui-stack backend and use that stack to run tests against frontend
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
       - develop
       - master
       - testnet
+      - ryardley/backend-tests-frontend
 
 jobs:
   build_ui_stack:
@@ -19,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Use Node.js
         uses: actions/setup-node@v2.1.4
         with:
@@ -29,9 +33,6 @@ jobs:
         with:
           go-version: ^1.15
         id: go
-
-      - name: Check out code
-        uses: actions/checkout@v2
 
       - name: Log into registry
         run: echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
@@ -63,5 +64,49 @@ jobs:
 
       - name: Build and push docker image
         run: yarn stack --push
+        env:
+          CI: true
+
+      - name: Save commit hash to env var
+        run: echo "SIFNODE_COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+
+      - name: Remove node_modules
+        run: rm -rf node_modules
+
+      - name: Check out sifchain-ui
+        uses: actions/checkout@v2
+        with:
+          repository: "Sifchain/sifchain-ui"
+          ref: "develop" # TODO: change to master once we have something deployed on the frontend
+          token: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Ensure we have env vars sharing
+        run: echo "This is the commit -> $SIFNODE_COMMIT_SHA"
+
+      - name: Pull instant stack image
+        run: docker pull ghcr.io/sifchain/sifnode/ui-stack:$SIFNODE_COMMIT_SHA
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path-2
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache Node.js modules
+        id: yarn-cache-2
+        uses: actions/cache@v2.1.3
+        with:
+          path: ${{ steps.yarn-cache-dir-path-2.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --silent
+
+      - uses: microsoft/playwright-github-action@v1
+
+      - name: Build e2e App
+        run: cd e2e && yarn install --frozen-lockfile
+
+      - name: Run e2e Tests
+        run: yarn build --tag $SIFNODE_COMMIT_SHA && yarn e2e --tag $SIFNODE_COMMIT_SHA
         env:
           CI: true

--- a/.github/workflows/ui-stack.yml
+++ b/.github/workflows/ui-stack.yml
@@ -9,7 +9,6 @@ on:
       - develop
       - master
       - testnet
-      - ryardley/backend-tests-frontend
 
 jobs:
   build_ui_stack:

--- a/ui/README.md
+++ b/ui/README.md
@@ -8,8 +8,9 @@ This code is managed by the frontend team.
 
 | Script                       | Description                                                                                                                  |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `yarn stack`                 | Launch stack from scratch.                                                                                                   |
+| `yarn stack`                 | Launch stack from scratch building sifnode.                                                                                  |
 | `yarn start`                 | Start the stack from the saved snapshot                                                                                      |
+| `yarn build`                 | Build and prepare the chains                                                                                                 |
 | `yarn stack --save-snapshot` | Launch the stack then save the snapshot files                                                                                |
 | `yarn stack --push`          | Take snapshot files that have already been saved and wrap them in a docker image and push it to the registry for consumption |
 


### PR DESCRIPTION
This is WIP and is forked from an active PR which is waiting to be merged -> https://github.com/Sifchain/sifnode/pull/1458 once that is merged this can follow quickly to maintain adequate test coverage. I will start by setting this to target the `ryardley/438-remove-ui-code` branch for greater readability but once that is merged this can target develop.

Get backend testing frontend code

So the idea here is that we need to avoid the situation where a breaking change gets merged to develop on sifnode then gets deployed without the frontend being ready to accept and manage the change. At worst this is going to require the backend teams and frontend teams to coordinate releases on the odd occasion that there are breaking changes from the backend.

- [x] docs changes
- [x] github action to follow ui-stack action. Should checkout sifchain-ui/master code and run e2e tests against local build and serve initially 
- [ ] In another PR: Change to point directly at live site once deployed with cookie switching enabled
