### PR TITLE
Add cosmos branch to ui-stack build list

### DIFF
--- a/.github/workflows/ui-stack.yml
+++ b/.github/workflows/ui-stack.yml
@@ -9,6 +9,7 @@ on:
       - develop
       - master
       - testnet
+      - feature/cosmos-0.42
 
 jobs:
   build_ui_stack:


### PR DESCRIPTION
This means that every time we push to `feature/cosmos-0.42` a ui-stack image is created.

We should be able to then test the frontend against the `feature/cosmos-0.42` stable tag. Eg.

`yarn e2e --tag feature/cosmos-0.42`