### PR TITLE
Call sifgen network create directly instead of using the rake task

### DIFF
--- a/test/integration/setup_sifchain.sh
+++ b/test/integration/setup_sifchain.sh
@@ -22,8 +22,7 @@ then
   rm -rf $NETWORKDIR && mkdir $NETWORKDIR
 fi
 mkdir -p $NETWORKDIR
-
-BASEDIR=${BASEDIR} rake genesis:network:scaffold['localnet']
+sifgen network create localnet 1 $NETWORKDIR 192.168.1.2 $NETWORKDIR/network-definition.yml --keyring-backend file  --mint-amount 999999000000000000000000000rowan,1370000000000000000ibc/FEEDFACEFEEDFACEFEEDFACEFEEDFACEFEEDFACEFEEDFACEFEEDFACEFEEDFACE
 
 set_persistant_env_var NETDEF $NETWORKDIR/network-definition.yml $envexportfile
 set_persistant_env_var NETDEF_JSON $datadir/netdef.json $envexportfile


### PR DESCRIPTION
This should work around the problem with having the rake files removed from the deploy/ directory