### PR TITLE
Replacing the ownable pattern with RBAC

### DIFF
--- a/smart-contracts/contracts/BridgeBank/IbcToken.sol
+++ b/smart-contracts/contracts/BridgeBank/IbcToken.sol
@@ -2,14 +2,13 @@
 pragma solidity 0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
 /**
  * @title IbcToken
  * @dev Mintable, ERC20Burnable, ERC20 compatible BankToken for use by BridgeBank
  **/
-contract IbcToken is ERC20Burnable, Ownable, AccessControl {
+contract IbcToken is ERC20Burnable, AccessControl {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     /**
@@ -27,7 +26,7 @@ contract IbcToken is ERC20Burnable, Ownable, AccessControl {
         string memory _symbol,
         uint8 _tokenDecimals,
         string memory _cosmosDenom
-    ) ERC20(_name, _symbol) Ownable() {
+    ) ERC20(_name, _symbol) {
         _decimals = _tokenDecimals;
         cosmosDenom = _cosmosDenom;
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -56,7 +55,7 @@ contract IbcToken is ERC20Burnable, Ownable, AccessControl {
      * @param denom The new cosmos denom
      * @return true if the operation succeeds
      */
-    function setDenom(string calldata denom) external onlyOwner returns (bool) {
+    function setDenom(string calldata denom) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
         cosmosDenom = denom;
         return true;
     }

--- a/smart-contracts/test/test_ibcToken.js
+++ b/smart-contracts/test/test_ibcToken.js
@@ -256,6 +256,14 @@ describe("Test IBC Token", function () {
     // check if owner received the minter role
     hasMinterRole = await ibcToken.hasRole(MINTER_ROLE, owner.address);
     expect(hasMinterRole).to.be.true;
+
+    // new admin changes the cosmosDenom:
+    await expect(ibcToken.connect(userOne).setDenom(anotherDenom))
+      .to.be.fulfilled;
+
+    // check if the denom changed
+    const newDenom = await ibcToken.cosmosDenom();
+    expect(newDenom).to.be.equal(anotherDenom);
   });
 
   it("should allow owner to set the cosmosDenom", async function () {
@@ -269,6 +277,8 @@ describe("Test IBC Token", function () {
 
   it("should NOT allow a user to set the cosmosDenom", async function () {
     await expect(ibcToken.connect(userOne).setDenom(anotherDenom))
-      .to.be.revertedWith("Ownable: caller is not the owner");
+      .to.be.revertedWith(
+        `AccessControl: account ${userOne.address.toLowerCase()} is missing role ${DEFAULT_ADMIN_ROLE}`
+      );
   });
 });


### PR DESCRIPTION
- [x] Remove the Ownable contract
- [x] Only the DEFAULT_ADMIN_ROLE can change the cosmos denom
- [x] Adjust unit tests