### PR TITLE
Add Current & Upcoming Reward Program Types to DistributionType Enum

### DIFF
--- a/proto/sifnode/dispensation/v1/types.proto
+++ b/proto/sifnode/dispensation/v1/types.proto
@@ -22,6 +22,12 @@ enum DistributionType {
   DISTRIBUTION_TYPE_VALIDATOR_SUBSIDY = 2;
   // Liquidity mining distribution type
   DISTRIBUTION_TYPE_LIQUIDITY_MINING = 3;
+  // 0.42 Cosmos IBC Rewards Program v1 distribution type
+  DISTRIBUTION_TYPE_LIQUIDITY_MINING_IBC_V1 = 4;
+  // Akash rewards program v1 distribution type
+  DISTRIBUTION_TYPE_LIQUIDITY_MINING_AKASH_V1 = 5;
+  // Peggy rewards program v1 distribution type
+  DISTRIBUTION_TYPE_LIQUIDITY_MINING_PEGGY_V1 = 6;
 }
 
 // Claim status enum


### PR DESCRIPTION
Summary:
* Updates `DistributionType` with types for upcoming reward programs
* Adds `DISTRIBUTION_TYPE_LIQUIDITY_MINING_IBC_V1`, `DISTRIBUTION_TYPE_LIQUIDITY_MINING_AKASH_V1`, and `DISTRIBUTION_TYPE_LIQUIDITY_MINING_PEGGY_V1`


Optimally, we may want to shift toward an individual `RewardProgramType` that points to specific reward programs rather than categorizing them, as `DISTRIBUTION_TYPE_LIQUIDITY_MINING` does.

If there is not currently bandwidth to make this happen, custom distribution types as implemented are a fairly straightforward solution.

Additional steps may be required to properly implement this addition, but the implemented changes provide an outline of what updates are needed.