### PR TITLE
witness lock burn nonce support

### DIFF
--- a/proto/sifnode/dispensation/v1/types.proto
+++ b/proto/sifnode/dispensation/v1/types.proto
@@ -66,7 +66,8 @@ message Distribution {
 message UserClaim {
   string user_address = 1;
   DistributionType user_claim_type = 2;
-  string user_claim_time = 3 [(gogoproto.customtype) = "github.com/gogo/protobuf/types.Timestamp"];
+  string user_claim_time = 3
+      [ (gogoproto.customtype) = "github.com/gogo/protobuf/types.Timestamp" ];
 }
 
 message UserClaims { repeated UserClaim user_claims = 1; }

--- a/proto/sifnode/ethbridge/v1/query.proto
+++ b/proto/sifnode/ethbridge/v1/query.proto
@@ -18,6 +18,9 @@ service Query {
   // LockBurnNonce query lock burn nonce for a relayer in a network
   rpc LockBurnNonce(QueryLockBurnNonceRequest)
       returns (QueryLockBurnNonceResponse) {}
+  // WitnessLockBurnNonce query lock burn nonce for a relayer in a network
+  rpc WitnessLockBurnNonce(QueryWitnessLockBurnNonceRequest)
+      returns (QueryWitnessLockBurnNonceResponse) {}
 }
 
 // QueryEthProphecyRequest payload for EthProphecy rpc query
@@ -83,3 +86,15 @@ message QueryLockBurnNonceRequest {
 
 // QueryLockBurnNonceResponse return LockBurnNonce
 message QueryLockBurnNonceResponse { uint64 lock_burn_nonce = 1; }
+
+// QueryWitnessLockBurnNonceRequest payload for LockBurnNonce rpc query
+message QueryWitnessLockBurnNonceRequest {
+  sifnode.oracle.v1.NetworkDescriptor network_descriptor = 1;
+  string relayer_val_address = 2;
+}
+
+// QueryWitnessLockBurnNonceResponse return WitnessLockBurnNonce
+message QueryWitnessLockBurnNonceResponse {
+  uint64 witness_lock_burn_nonce = 1;
+}
+

--- a/proto/sifnode/tokenregistry/v1/query.proto
+++ b/proto/sifnode/tokenregistry/v1/query.proto
@@ -14,7 +14,5 @@ service Query {
   }
 }
 
-message QueryEntriesResponse {
-    Registry registry = 1;
-}
+message QueryEntriesResponse { Registry registry = 1; }
 message QueryEntriesRequest {}

--- a/proto/sifnode/tokenregistry/v1/tx.proto
+++ b/proto/sifnode/tokenregistry/v1/tx.proto
@@ -16,15 +16,11 @@ message MsgRegister {
   RegistryEntry entry = 2;
 }
 
-message MsgRegisterResponse {
-
-}
+message MsgRegisterResponse {}
 
 message MsgDeregister {
   string from = 1;
   string denom = 2;
 }
 
-message MsgDeregisterResponse {
-
-}
+message MsgDeregisterResponse {}

--- a/proto/sifnode/tokenregistry/v1/types.proto
+++ b/proto/sifnode/tokenregistry/v1/types.proto
@@ -10,14 +10,12 @@ message GenesisState {
   Registry registry = 2;
 }
 
-message Registry {
-  repeated RegistryEntry entries = 1;
-}
+message Registry { repeated RegistryEntry entries = 1; }
 
 enum Permission {
   UNSPECIFIED = 0;
   CLP = 1;
-  IBCEXPORT =  2;
+  IBCEXPORT = 2;
   IBCIMPORT = 3;
 }
 
@@ -36,23 +34,22 @@ message RegistryEntry {
   string external_symbol = 12;
   string transfer_limit = 13;
   repeated Permission permissions = 15;
-  // The name of denomination unit of this token that is the smallest unit stored.
-  // IBC imports of this RegistryEntry convert and store funds as unit_denom.
-  // Several different denom units of a token may be imported into this same unit denom,
-  // they should all be stored under the same unit_denom if they are the same token.
-  // When exporting a RegistryEntry where unit_denom != denom,
-  // then unit_denom can, in future, be used to indicate the source of funds for a denom unit that does not actually
-  // exist on chain, enabling other chains to overcome the uint64 limit on the packet level and import large amounts
-  // of high precision tokens easily.
-  // ie. microrowan -> rowan
-  // i.e rowan -> rowan
+  // The name of denomination unit of this token that is the smallest unit
+  // stored. IBC imports of this RegistryEntry convert and store funds as
+  // unit_denom. Several different denom units of a token may be imported into
+  // this same unit denom, they should all be stored under the same unit_denom
+  // if they are the same token. When exporting a RegistryEntry where unit_denom
+  // != denom, then unit_denom can, in future, be used to indicate the source of
+  // funds for a denom unit that does not actually exist on chain, enabling
+  // other chains to overcome the uint64 limit on the packet level and import
+  // large amounts of high precision tokens easily. ie. microrowan -> rowan i.e
+  // rowan -> rowan
   string unit_denom = 16;
-  // The name of denomination unit of this token that should appear on counterparty chain when this unit is exported.
-  // If empty, the denom is exported as is.
-  // Generally this will only be used to map a high precision (unit_denom) to a lower precision,
-  // to overcome the current uint64 limit on the packet level.
-  // i.e rowan -> microrowan
-  // i.e microrowan -> microrowan
+  // The name of denomination unit of this token that should appear on
+  // counterparty chain when this unit is exported. If empty, the denom is
+  // exported as is. Generally this will only be used to map a high precision
+  // (unit_denom) to a lower precision, to overcome the current uint64 limit on
+  // the packet level. i.e rowan -> microrowan i.e microrowan -> microrowan
   string ibc_counterparty_denom = 17;
-  string ibc_counterparty_chain_id =  18;
+  string ibc_counterparty_chain_id = 18;
 }

--- a/x/ethbridge/types/querier.go
+++ b/x/ethbridge/types/querier.go
@@ -6,9 +6,10 @@ import (
 
 // query endpoints supported by the oracle Querier
 const (
-	QueryEthProphecy         = "prophecies"
-	QueryCrosschainFeeConfig = "crosschainFeeConfig"
-	QueryLockBurnNonce       = "lockBurnNonce"
+	QueryEthProphecy          = "prophecies"
+	QueryCrosschainFeeConfig  = "crosschainFeeConfig"
+	QueryLockBurnNonce        = "lockBurnNonce"
+	QueryWitnessLockBurnNonce = "witnessLockBurnNonce"
 )
 
 // NewQueryEthProphecyRequest creates a new QueryEthProphecyParams
@@ -53,5 +54,20 @@ func NewLockBurnNonceRequest(networkDescriptor oracletypes.NetworkDescriptor, re
 func NewLockBurnNonceResponse(lockBurnNonce uint64) QueryLockBurnNonceResponse {
 	return QueryLockBurnNonceResponse{
 		LockBurnNonce: lockBurnNonce,
+	}
+}
+
+// NewWitnessLockBurnNonceRequest creates a new QueryWitnessLockBurnNonceRequest
+func NewWitnessLockBurnNonceRequest(networkDescriptor oracletypes.NetworkDescriptor, relayerValAddress string) *QueryWitnessLockBurnNonceRequest {
+	return &QueryWitnessLockBurnNonceRequest{
+		NetworkDescriptor: networkDescriptor,
+		RelayerValAddress: relayerValAddress,
+	}
+}
+
+// NewWitnessLockBurnNonceResponse creates a new QueryWitnessLockBurnNonceResponse instance
+func NewWitnessLockBurnNonceResponse(lockBurnNonce uint64) QueryWitnessLockBurnNonceResponse {
+	return QueryWitnessLockBurnNonceResponse{
+		WitnessLockBurnNonce: lockBurnNonce,
 	}
 }

--- a/x/oracle/keeper/witnessLockBurnNonce.go
+++ b/x/oracle/keeper/witnessLockBurnNonce.go
@@ -1,0 +1,43 @@
+package keeper
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/Sifchain/sifnode/x/oracle/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// SetWitnessLockBurnNonce set the Witness lock burn nonce for each relayer
+func (k Keeper) SetWitnessLockBurnNonce(ctx sdk.Context, networkDescriptor types.NetworkDescriptor, valAccount sdk.ValAddress, newNonce uint64) {
+	store := ctx.KVStore(k.storeKey)
+	key := k.getWitnessLockBurnNoncePrefix(networkDescriptor, valAccount)
+
+	bs := make([]byte, 8)
+	binary.BigEndian.PutUint64(bs, newNonce)
+
+	store.Set(key, bs)
+}
+
+// GetWitnessLockBurnNonce return Witness lock burn nonce
+func (k Keeper) GetWitnessLockBurnNonce(ctx sdk.Context, networkDescriptor types.NetworkDescriptor, valAccount sdk.ValAddress) uint64 {
+	store := ctx.KVStore(k.storeKey)
+	key := k.getWitnessLockBurnNoncePrefix(networkDescriptor, valAccount)
+
+	// nonce start from 1, 0 represent the relayer is a new one
+	if !store.Has(key) {
+		return 0
+	}
+
+	bz := store.Get(key)
+	return binary.BigEndian.Uint64(bz)
+}
+
+// getWitnessLockBurnNoncePrefix return storage prefix
+func (k Keeper) getWitnessLockBurnNoncePrefix(networkDescriptor types.NetworkDescriptor, valAccount sdk.ValAddress) []byte {
+	bytebuf := bytes.NewBuffer([]byte{})
+	_ = binary.Write(bytebuf, binary.BigEndian, networkDescriptor)
+	tmpKey := append(types.WitnessLockBurnNoncePrefix, bytebuf.Bytes()...)
+	return append(tmpKey, valAccount...)
+}

--- a/x/oracle/keeper/witnessLockBurnNonce_test.go
+++ b/x/oracle/keeper/witnessLockBurnNonce_test.go
@@ -1,0 +1,38 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Sifchain/sifnode/x/ethbridge/test"
+)
+
+const (
+	testNetwork       = 1
+	testAddress       = "cosmosvaloper1mnfm9c7cdgqnkk66sganp78m0ydmcr4pn7fqfk"
+	testLockBurnNonce = uint64(10)
+	testInitNonce     = uint64(0)
+)
+
+func TestSetWitnessLockBurnNonce(t *testing.T) {
+	var ctx, _, _, _, keeper, _, _, _ = test.CreateTestKeepers(t, 0.7, []int64{3, 3}, "")
+	testCosmosAddress, err := sdk.ValAddressFromBech32(testAddress)
+	require.NoError(t, err)
+
+	keeper.SetWitnessLockBurnNonce(ctx, testNetwork, testCosmosAddress, testLockBurnNonce)
+
+	lockBurnNonce := keeper.GetWitnessLockBurnNonce(ctx, testNetwork, testCosmosAddress)
+	assert.Equal(t, lockBurnNonce, testLockBurnNonce)
+}
+
+func TestGetWitnessLockBurnNonce(t *testing.T) {
+	var ctx, _, _, _, keeper, _, _, _ = test.CreateTestKeepers(t, 0.7, []int64{3, 3}, "")
+	testCosmosAddress, err := sdk.ValAddressFromBech32(testAddress)
+	require.NoError(t, err)
+
+	lockBurnNonce := keeper.GetWitnessLockBurnNonce(ctx, testNetwork, testCosmosAddress)
+	assert.Equal(t, lockBurnNonce, testInitNonce)
+}

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -21,4 +21,5 @@ var (
 	CrossChainFeePrefix         = []byte{0x03}
 	SignaturePrefix             = []byte{0x04}
 	GlobalNonceProphecyIDPrefix = []byte{0x05}
+	WitnessLockBurnNoncePrefix  = []byte{0x06}
 )


### PR DESCRIPTION
Sifnode record the lock burn nonce for witness node and require the witness node send the transaction for sign prophecy in order. In the eblayer side, the level db will be removed.