### PR TITLE
Remove the whitelist being needed to lock tokens in the bridgebank

### DIFF
--- a/smart-contracts/contracts/BridgeBank/BridgeBank.sol
+++ b/smart-contracts/contracts/BridgeBank/BridgeBank.sol
@@ -594,7 +594,7 @@ contract BridgeBank is BankStorage,
         address tokenAddress,
         uint256 tokenAmount,
         uint256 _lockBurnNonce
-    ) private onlyEthTokenWhiteList(tokenAddress) validSifAddress(recipient) {
+    ) private onlyTokenNotInCosmosWhiteList(tokenAddress) validSifAddress(recipient) {
         IERC20 tokenToTransfer = IERC20(tokenAddress);
         // lock tokens
         tokenToTransfer.safeTransferFrom(

--- a/smart-contracts/contracts/BridgeBank/CosmosWhiteList.sol
+++ b/smart-contracts/contracts/BridgeBank/CosmosWhiteList.sol
@@ -35,7 +35,7 @@ contract CosmosWhiteList is CosmosWhiteListStorage {
     modifier onlyTokenNotInCosmosWhiteList(address _token) {
         require(
             !getCosmosTokenInWhiteList(_token),
-            "Only token not in whitelist can be locked"
+            "Only token not in cosmos whitelist can be locked"
         );
         _;
     }

--- a/smart-contracts/test/test_bridgeBankLock.js
+++ b/smart-contracts/test/test_bridgeBankLock.js
@@ -505,35 +505,47 @@ describe("Test Bridge Bank", function () {
       expect(await state.bridgeBank.getTokenInEthWhiteList(state.token1.address)).to.be.equal(true);
     });
 
-    it("should not allow user to lock ERC20 tokens that are not in eth whitelist", async function () {
+    it("should not allow user to lock ERC20 tokens that are in Cosmos whitelist", async function () {
+      // add token as BridgeToken
+      await state.bridgeBank.connect(owner).addExistingBridgeToken(state.token1.address);
+
       // Attempt to lock tokens
       await expect(state.bridgeBank.connect(userOne).lock(
         state.sender,
         state.token1.address,
         state.amount
-      )).to.be.revertedWith("Only token in eth whitelist can be transferred to cosmos");
+      )).to.be.revertedWith("Only token not in cosmos whitelist can be locked");
     });
 
-    it("should not allow user to multi-lock ERC20 tokens that are not in eth whitelist", async function () {
+    it("should not allow user to multi-lock ERC20 tokens if at least one of them is in cosmos whitelist", async function () {
+      // add token1 as BridgeToken
+      await state.bridgeBank.connect(owner).addExistingBridgeToken(state.token1.address);
+
       // Attempt to lock tokens
       await expect(state.bridgeBank.connect(userOne).multiLock(
         [state.sender, state.sender, state.sender],
         [state.token1.address, state.token2.address, state.token3.address],
         [state.amount, state.amount, state.amount]
-      )).to.be.revertedWith("Only token in eth whitelist can be transferred to cosmos");
+      )).to.be.revertedWith("Only token not in cosmos whitelist can be locked");
     });
 
-    it("should not allow user to multi-lock ERC20 tokens that are not in eth whitelist with multiLockBurn method", async function () {
+    it("should not allow user to multi-lock ERC20 tokens with multiLockBurn method if one of them is cosmos whitelist", async function () {
+      // add token1 as BridgeToken
+      await state.bridgeBank.connect(owner).addExistingBridgeToken(state.token1.address);
+
       // Attempt to lock tokens
       await expect(state.bridgeBank.connect(userOne).multiLockBurn(
         [state.sender, state.sender, state.sender],
         [state.token1.address, state.token2.address, state.token3.address],
         [state.amount, state.amount, state.amount],
         [false, false, false]
-      )).to.be.revertedWith("Only token in eth whitelist can be transferred to cosmos");
+      )).to.be.revertedWith("Only token not in cosmos whitelist can be locked");
     });
 
-    it("should not allow user to multi-lock and burn ERC20 tokens not in eth whitelist and rowan with multiLockBurn method", async function () {
+    it("should not allow user to multi-lock and burn ERC20 tokens and rowan with multiLockBurn method if at least one of them is in cosmos whitelist ", async function () {
+      // add token1 as BridgeToken
+      await state.bridgeBank.connect(owner).addExistingBridgeToken(state.token1.address);
+
       // approve bridgebank to spend rowan
       await state.rowan.connect(userOne).approve(
         state.bridgeBank.address,
@@ -546,7 +558,7 @@ describe("Test Bridge Bank", function () {
         [state.token1.address, state.token2.address, state.rowan.address],
         [state.amount, state.amount, state.amount],
         [false, false, true]
-      )).to.be.revertedWith("Only token in eth whitelist can be transferred to cosmos");
+      )).to.be.revertedWith("Only token not in cosmos whitelist can be locked");
     });
   });
 });


### PR DESCRIPTION
"Remove the whitelist being needed to lock tokens in the bridgebank.
Instead, add a check that whenever a token is locked, it is not in the cosmoswhitelist, and if it is, revert."