### PR TITLE
Update IXO Testnet & Refactor Registry Script Structure

### DIFF
--- a/scripts/ibc/tokenregistration/deregister-all-betanet.sh
+++ b/scripts/ibc/tokenregistration/deregister-all-betanet.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-1 \
-  KEYRING_BACKEND=test \
-  SIF_NODE=https://rpc.sifchain.finance:443 ./template/deregister-all.sh

--- a/scripts/ibc/tokenregistration/deregister-all-devnet.sh
+++ b/scripts/ibc/tokenregistration/deregister-all-devnet.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-devnet-1 \
-  KEYRING_BACKEND=test \
-  SIF_NODE=https://rpc-devnet.sifchain.finance:443 ./template/deregister-all.sh

--- a/scripts/ibc/tokenregistration/deregister-all-testnet.sh
+++ b/scripts/ibc/tokenregistration/deregister-all-testnet.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-testnet-1 \
-  KEYRING_BACKEND=test \
-  SIF_NODE=https://rpc-testnet.sifchain.finance:443 ./template/deregister-all.sh

--- a/scripts/ibc/tokenregistration/deregister-all.sh
+++ b/scripts/ibc/tokenregistration/deregister-all.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+. ./envs/$1.sh 
 
 TOKEN_REGISTRY_ADMIN_ADDRESS="sif1tpypxpppcf5lea47vcvgy09675nllmcucxydvu"
 
-sifnoded tx tokenregistry register-all ./$SIFCHAIN_ID/tokenregistry.json \
+sifnoded tx tokenregistry deregister-all ./$SIFCHAIN_ID/tokenregistry.json \
   --node $SIF_NODE \
   --chain-id $SIFCHAIN_ID \
   --from $TOKEN_REGISTRY_ADMIN_ADDRESS \

--- a/scripts/ibc/tokenregistration/deregister-one.sh
+++ b/scripts/ibc/tokenregistration/deregister-one.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+. ./envs/$1.sh 
+
+TOKEN_REGISTRY_ADMIN_ADDRESS="sif1tpypxpppcf5lea47vcvgy09675nllmcucxydvu"
+
+sifnoded tx tokenregistry deregister $2 \
+  --node $SIF_NODE \
+  --chain-id $SIFCHAIN_ID \
+  --from $TOKEN_REGISTRY_ADMIN_ADDRESS \
+  --keyring-backend $KEYRING_BACKEND \
+  --gas=500000 \
+  --gas-prices=0.5rowan \
+  -y

--- a/scripts/ibc/tokenregistration/envs/betanet.sh
+++ b/scripts/ibc/tokenregistration/envs/betanet.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 SIFCHAIN_ID=sifchain-1 \
+  KEYRING_BACKEND=test \
+  SIF_NODE=https://rpc.sifchain.finance:443 \
   COSMOS_BASE_DENOM=uatom \
   COSMOS_CHANNEL_ID=channel-0 \
   COSMOS_COUNTERPARTY_CHANNEL_ID=channel-192 \
@@ -32,4 +34,4 @@ SIFCHAIN_ID=sifchain-1 \
   OSMOSIS_COUNTERPARTY_CHANNEL_ID= \
   CRYPTO_ORG_CHAIN_ID=crypto-org-chain-mainnet-1 \
   CRYPTO_ORG_CHANNEL_ID=channel-9 \
-  CRYPTO_ORG_COUNTERPARTY_CHANNEL_ID=channel-33 ./template/generate-ibc-jsons.sh
+  CRYPTO_ORG_COUNTERPARTY_CHANNEL_ID=channel-33 

--- a/scripts/ibc/tokenregistration/envs/devnet.sh
+++ b/scripts/ibc/tokenregistration/envs/devnet.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 SIFCHAIN_ID=sifchain-devnet-1 \
+  KEYRING_BACKEND=test \
+  SIF_NODE=https://rpc-devnet.sifchain.finance:443 \
   COSMOS_BASE_DENOM=uphoton \
   COSMOS_CHANNEL_ID=channel-114 \
   COSMOS_COUNTERPARTY_CHANNEL_ID=channel-26 \
@@ -32,4 +34,4 @@ SIFCHAIN_ID=sifchain-devnet-1 \
   TERRA_COUNTERPARTY_CHANNEL_ID=channel-3 \
   OSMOSIS_CHAIN_ID=osmosis-1 \
   OSMOSIS_CHANNEL_ID=channel-122 \
-  OSMOSIS_COUNTERPARTY_CHANNEL_ID=channel-34 ./template/generate-ibc-jsons.sh
+  OSMOSIS_COUNTERPARTY_CHANNEL_ID=channel-34 

--- a/scripts/ibc/tokenregistration/envs/testnet.sh
+++ b/scripts/ibc/tokenregistration/envs/testnet.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 SIFCHAIN_ID=sifchain-testnet-1 \
+  KEYRING_BACKEND=test \
+  SIF_NODE=https://rpc-testnet.sifchain.finance:443 \
   COSMOS_BASE_DENOM=uphoton \
   COSMOS_CHANNEL_ID=channel-11 \
   COSMOS_COUNTERPARTY_CHANNEL_ID=channel-27 \
@@ -27,9 +29,12 @@ SIFCHAIN_ID=sifchain-testnet-1 \
   JUNO_CHAIN_ID=juno-1 \
   JUNO_CHANNEL_ID=channel-36 \
   JUNO_COUNTERPARTY_CHANNEL_ID=channel-4 \
+  IXO_CHAIN_ID=impacthub-3 \
+  IXO_CHANNEL_ID=channel-38 \
+  IXO_COUNTERPARTY_CHANNEL_ID=channel-12 \
   TERRA_CHAIN_ID=bombay-12 \
   TERRA_CHANNEL_ID=channel-33 \
   TERRA_COUNTERPARTY_CHANNEL_ID=channel-0 \
   CRYPTO_ORG_CHAIN_ID=crypto-org-chain-mainnet-1 \
   CRYPTO_ORG_CHANNEL_ID=channel-16 \
-  CRYPTO_ORG_COUNTERPARTY_CHANNEL_ID=channel-32 ./template/generate-ibc-jsons.sh
+  CRYPTO_ORG_COUNTERPARTY_CHANNEL_ID=channel-32

--- a/scripts/ibc/tokenregistration/generate-all-betanet.sh
+++ b/scripts/ibc/tokenregistration/generate-all-betanet.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-1 ./template/generate-all.sh

--- a/scripts/ibc/tokenregistration/generate-all-devnet.sh
+++ b/scripts/ibc/tokenregistration/generate-all-devnet.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-devnet-1 ./template/generate-all.sh

--- a/scripts/ibc/tokenregistration/generate-all-testnet.sh
+++ b/scripts/ibc/tokenregistration/generate-all-testnet.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-testnet-1 ./template/generate-all.sh

--- a/scripts/ibc/tokenregistration/generate-all.sh
+++ b/scripts/ibc/tokenregistration/generate-all.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+. ./envs/$1.sh 
 
 mkdir -p ./$SIFCHAIN_ID
 rm -f ./$SIFCHAIN_ID/temp.json

--- a/scripts/ibc/tokenregistration/generate-ibc-jsons.sh
+++ b/scripts/ibc/tokenregistration/generate-ibc-jsons.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # REMEMBER to use right counterparty network denom,
 # i.e for BetaNet use MAINNET denom registered on counterparty chain, not denom registered on counterparty TESTNET
 # i.e for BetaNet, uatom not uphoton, and for TestNet uphoton not uatom.
@@ -19,6 +17,8 @@
 #SENTINEL_CHANNEL_ID="channel-"
 #SENTINEL_COUNTERPARTY_CHANNEL_ID="channel-"
 #SENTINEL_CHAIN_ID=""
+
+. ./envs/$1.sh 
 
 echo "\n\ngenerating and storing all entries for network $SIFCHAIN_ID"
 
@@ -201,6 +201,24 @@ sifnoded q tokenregistry generate \
 	--token_permission_ibc_export=true \
 	--token_permission_ibc_import=true | jq > $SIFCHAIN_ID/juno.json
 
-echo "\n\ngenerated entry for $OSMOSIS_CHAIN_ID"
+echo "\n\ngenerated entry for $JUNO_CHAIN_ID"
 
 cat $SIFCHAIN_ID/juno.json | jq
+
+sifnoded q tokenregistry generate \
+	--token_base_denom=uixo \
+	--token_ibc_counterparty_chain_id=$IXO_CHAIN_ID \
+  --token_ibc_channel_id=$IXO_CHANNEL_ID \
+  --token_ibc_counterparty_channel_id=$IXO_COUNTERPARTY_CHANNEL_ID \
+	--token_ibc_counterparty_denom="" \
+	--token_unit_denom="" \
+	--token_decimals=6 \
+	--token_display_name="" \
+	--token_external_symbol="" \
+	--token_permission_clp=true \
+	--token_permission_ibc_export=true \
+	--token_permission_ibc_import=true | jq > $SIFCHAIN_ID/ixo.json
+
+echo "\n\ngenerated entry for $IXO_CHAIN_ID"
+
+cat $SIFCHAIN_ID/ixo.json | jq

--- a/scripts/ibc/tokenregistration/register-all-betanet.sh
+++ b/scripts/ibc/tokenregistration/register-all-betanet.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-1 \
-  KEYRING_BACKEND=test \
-  SIF_NODE=https://rpc.sifchain.finance:443 ./template/register-all.sh

--- a/scripts/ibc/tokenregistration/register-all-devnet.sh
+++ b/scripts/ibc/tokenregistration/register-all-devnet.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-devnet-1 \
-  KEYRING_BACKEND=test \
-  SIF_NODE=https://rpc-devnet.sifchain.finance:443 ./template/register-all.sh

--- a/scripts/ibc/tokenregistration/register-all-testnet.sh
+++ b/scripts/ibc/tokenregistration/register-all-testnet.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-SIFCHAIN_ID=sifchain-testnet-1 \
-  KEYRING_BACKEND=test \
-  SIF_NODE=https://rpc-testnet.sifchain.finance:443 ./template/register-all.sh

--- a/scripts/ibc/tokenregistration/register-all.sh
+++ b/scripts/ibc/tokenregistration/register-all.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+. ./envs/$1.sh 
+
+TOKEN_REGISTRY_ADMIN_ADDRESS="sif1tpypxpppcf5lea47vcvgy09675nllmcucxydvu"
+
+sifnoded tx tokenregistry register-all ./$SIFCHAIN_ID/tokenregistry.json \
+  --node $SIF_NODE \
+  --chain-id $SIFCHAIN_ID \
+  --from $TOKEN_REGISTRY_ADMIN_ADDRESS \
+  --keyring-backend $KEYRING_BACKEND \
+  --gas=500000 \
+  --gas-prices=0.5rowan \
+  -y

--- a/scripts/ibc/tokenregistration/register-one.sh
+++ b/scripts/ibc/tokenregistration/register-one.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+. ./envs/$1.sh 
 
 TOKEN_REGISTRY_ADMIN_ADDRESS="sif1tpypxpppcf5lea47vcvgy09675nllmcucxydvu"
 
-sifnoded tx tokenregistry deregister-all ./$SIFCHAIN_ID/tokenregistry.json \
+sifnoded tx tokenregistry register ./$SIFCHAIN_ID/$2.json \
   --node $SIF_NODE \
   --chain-id $SIFCHAIN_ID \
   --from $TOKEN_REGISTRY_ADMIN_ADDRESS \

--- a/scripts/ibc/tokenregistration/sifchain-1/ixo.json
+++ b/scripts/ibc/tokenregistration/sifchain-1/ixo.json
@@ -1,0 +1,27 @@
+{
+  "entries": [
+    {
+      "is_whitelisted": true,
+      "decimals": "6",
+      "denom": "uixo",
+      "base_denom": "uixo",
+      "path": "",
+      "ibc_channel_id": "",
+      "ibc_counterparty_channel_id": "",
+      "display_name": "",
+      "display_symbol": "",
+      "network": "",
+      "address": "",
+      "external_symbol": "",
+      "transfer_limit": "",
+      "permissions": [
+        "CLP",
+        "IBCEXPORT",
+        "IBCIMPORT"
+      ],
+      "unit_denom": "",
+      "ibc_counterparty_denom": "",
+      "ibc_counterparty_chain_id": ""
+    }
+  ]
+}

--- a/scripts/ibc/tokenregistration/sifchain-1/terra.json
+++ b/scripts/ibc/tokenregistration/sifchain-1/terra.json
@@ -1,0 +1,27 @@
+{
+  "entries": [
+    {
+      "is_whitelisted": true,
+      "decimals": "6",
+      "denom": "uluna",
+      "base_denom": "uluna",
+      "path": "",
+      "ibc_channel_id": "",
+      "ibc_counterparty_channel_id": "",
+      "display_name": "Luna",
+      "display_symbol": "",
+      "network": "",
+      "address": "",
+      "external_symbol": "",
+      "transfer_limit": "",
+      "permissions": [
+        "CLP",
+        "IBCEXPORT",
+        "IBCIMPORT"
+      ],
+      "unit_denom": "",
+      "ibc_counterparty_denom": "",
+      "ibc_counterparty_chain_id": ""
+    }
+  ]
+}

--- a/scripts/ibc/tokenregistration/sifchain-devnet-1/ixo.json
+++ b/scripts/ibc/tokenregistration/sifchain-devnet-1/ixo.json
@@ -1,0 +1,27 @@
+{
+  "entries": [
+    {
+      "is_whitelisted": true,
+      "decimals": "6",
+      "denom": "uixo",
+      "base_denom": "uixo",
+      "path": "",
+      "ibc_channel_id": "",
+      "ibc_counterparty_channel_id": "",
+      "display_name": "",
+      "display_symbol": "",
+      "network": "",
+      "address": "",
+      "external_symbol": "",
+      "transfer_limit": "",
+      "permissions": [
+        "CLP",
+        "IBCEXPORT",
+        "IBCIMPORT"
+      ],
+      "unit_denom": "",
+      "ibc_counterparty_denom": "",
+      "ibc_counterparty_chain_id": ""
+    }
+  ]
+}

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/ixo.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/ixo.json
@@ -1,0 +1,27 @@
+{
+  "entries": [
+    {
+      "is_whitelisted": true,
+      "decimals": "6",
+      "denom": "ibc/DB5B562539E53FB210C6BA370E2AA8ADE9621AD4083E22F7FD59456D03390670",
+      "base_denom": "uixo",
+      "path": "transfer/channel-37",
+      "ibc_channel_id": "channel-37",
+      "ibc_counterparty_channel_id": "channel-10",
+      "display_name": "",
+      "display_symbol": "",
+      "network": "",
+      "address": "",
+      "external_symbol": "",
+      "transfer_limit": "",
+      "permissions": [
+        "CLP",
+        "IBCEXPORT",
+        "IBCIMPORT"
+      ],
+      "unit_denom": "",
+      "ibc_counterparty_denom": "",
+      "ibc_counterparty_chain_id": "impacthub-3"
+    }
+  ]
+}


### PR DESCRIPTION
* Added IXO Testnet
* Reduced redundancy in registry scripts

### New commands:
Where `ixo` is any counterparty network and `testnet` is any network (testnet, devnet, or betanet):

 `sh ./deregister-one.sh testnet ixo`
 `sh ./generate-all.sh testnet`
 `sh ./generate-ibc-jsons.sh testnet`
`sh ./register-all.sh testnet`
`sh ./register-one.sh testnet ixo`