### PR TITLE
[ChainOps] Peggy Logging

### DIFF
--- a/cmd/ebrelayer/relayer/cosmos.go
+++ b/cmd/ebrelayer/relayer/cosmos.go
@@ -158,7 +158,6 @@ func (sub CosmosSub) Start(completionEvent *sync.WaitGroup, symbolTranslator *sy
 				}
 
 				for _, txLog := range block.TxsResults {
-					sub.SugaredLogger.Infow("block.TxsResults: ", "block.TxsResults: ", block.TxsResults)
 					for _, event := range txLog.Events {
 
 						claimType := getOracleClaimType(event.GetType())


### PR DESCRIPTION
Includes:

* Minor tweak to remove the logging of `block.TxsResults`. In times like we're in now, with a substantial amount of transactions per block, it generates a significant amount of logging data that appears to have little to no value.