### PR TITLE
[ChainOps] Build updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,32 +23,20 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v2.x
 
-      - if: contains(github.ref, 'devnet')
-        run: |
-          echo "CHAINNET=testnet" >> "$GITHUB_ENV"
-
-      - if: contains(github.ref, 'testnet')
-        run: |
-          echo "CHAINNET=testnet" >> "$GITHUB_ENV"
-
-      - if: contains(github.ref, 'betanet')
-        run: |
-          echo "CHAINNET=betanet" >> "$GITHUB_ENV"
-
-      - if: contains(github.ref, 'mainnet')
-        run: |
-          echo "CHAINNET=mainnet" >> "$GITHUB_ENV"
-
       - name: Build docker images
         run: |
-          echo ${{ env.CHAINNET }}
-          make CHAINNET=${{ env.CHAINNET }} IMAGE_TAG=${{ env.GITHUB_REF_SLUG }} BINARY=sifnoded build-image
-          make CHAINNET=${{ env.CHAINNET }} IMAGE_TAG=${{ env.GITHUB_REF_SLUG }} BINARY=ebrelayer build-image
+          make IMAGE_TAG=${{ env.GITHUB_REF_SLUG }} BINARY=sifnoded build-image
+          make IMAGE_TAG=${{ env.GITHUB_REF_SLUG }} BINARY=ebrelayer build-image
 
       - name: Push docker images
         run: |
           docker push sifchain/sifnoded:${{ env.GITHUB_REF_SLUG }}
           docker push sifchain/ebrelayer:${{ env.GITHUB_REF_SLUG }}
+
+      - name: Get version
+        id: version
+        run: |
+          echo "::set-output name=version::$(cat version)"
 
       - name: Release a new sifnoded binary
         uses: ./deploy/release
@@ -59,4 +47,10 @@ jobs:
           goversion: "1.16"
           project_path: "./cmd/sifnoded"
           binary_name: "sifnoded"
+          ldflags:
+            - -X github.com/cosmos/cosmos-sdk/version.Name=sifchain
+            - -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded
+            - -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded
+            - -X github.com/cosmos/cosmos-sdk/version.Version=${{ env.GITHUB_REF_SLUG }}
+            - -X github.com/cosmos/cosmos-sdk/version.Commit=${{ steps.version.outputs.version }}
           sha256sum: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,5 @@ jobs:
           goversion: "1.16"
           project_path: "./cmd/sifnoded"
           binary_name: "sifnoded"
-          ldflags:
-            - -X github.com/cosmos/cosmos-sdk/version.Name=sifchain
-            - -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded
-            - -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded
-            - -X github.com/cosmos/cosmos-sdk/version.Version=${{ env.GITHUB_REF_SLUG }}
-            - -X github.com/cosmos/cosmos-sdk/version.Commit=${{ steps.version.outputs.version }}
+          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ env.GITHUB_REF_SLUG }} -X github.com/cosmos/cosmos-sdk/version.Commit=${{ steps.version.outputs.version }}"
           sha256sum: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,33 +13,30 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
-          repository: Sifchain/sifchain-deploy
-          path: deploy
+          repository: Sifchain/sifchain-devops
+          path: sifchain-devops
           token: "${{ secrets.GIT_PAT }}"
 
       - name: Login to Docker Hub
         run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v2.x
-
-      - name: Build docker images
-        run: |
-          make IMAGE_TAG=${{ env.GITHUB_REF_SLUG }} BINARY=sifnoded build-image
-          make IMAGE_TAG=${{ env.GITHUB_REF_SLUG }} BINARY=ebrelayer build-image
-
-      - name: Push docker images
-        run: |
-          docker push sifchain/sifnoded:${{ env.GITHUB_REF_SLUG }}
-          docker push sifchain/ebrelayer:${{ env.GITHUB_REF_SLUG }}
 
       - name: Get version
         id: version
         run: |
           echo "::set-output name=version::$(cat version)"
 
+      - name: Build docker images
+        run: |
+          make IMAGE_TAG=${{ steps.version.outputs.version }} BINARY=sifnoded build-image
+          make IMAGE_TAG=${{ steps.version.outputs.version }} BINARY=ebrelayer build-image
+
+      - name: Push docker images
+        run: |
+          docker push sifchain/sifnoded:${{ steps.version.outputs.version }}
+          docker push sifchain/ebrelayer:${{ steps.version.outputs.version }}
+
       - name: Release a new sifnoded binary
-        uses: ./deploy/release
+        uses: ./sifchain-devops/release
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: linux
@@ -47,5 +44,5 @@ jobs:
           goversion: "1.16"
           project_path: "./cmd/sifnoded"
           binary_name: "sifnoded"
-          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ env.GITHUB_REF_SLUG }} -X github.com/cosmos/cosmos-sdk/version.Commit=${{ steps.version.outputs.version }}"
+          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ steps.version.outputs.version }} -X github.com/cosmos/cosmos-sdk/version.Commit=${GITHUB_SHA}"
           sha256sum: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
           docker push sifchain/sifnoded:${{ steps.version.outputs.version }}
           docker push sifchain/ebrelayer:${{ steps.version.outputs.version }}
 
+      - name: Get commit hash
+        id: hash
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Release a new sifnoded binary
         uses: ./sifchain-devops/release
         with:
@@ -44,5 +49,5 @@ jobs:
           goversion: "1.16"
           project_path: "./cmd/sifnoded"
           binary_name: "sifnoded"
-          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ steps.version.outputs.version }} -X github.com/cosmos/cosmos-sdk/version.Commit=${{ env.GITHUB_SHA }}"
+          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ steps.version.outputs.version }} -X github.com/cosmos/cosmos-sdk/version.Commit=${{ steps.hash.outputs.sha_short }}"
           sha256sum: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,5 +44,5 @@ jobs:
           goversion: "1.16"
           project_path: "./cmd/sifnoded"
           binary_name: "sifnoded"
-          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ steps.version.outputs.version }} -X github.com/cosmos/cosmos-sdk/version.Commit=${GITHUB_SHA}"
+          ldflags: "-X github.com/cosmos/cosmos-sdk/version.Name=sifchain -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded -X github.com/cosmos/cosmos-sdk/version.Version=${{ steps.version.outputs.version }} -X github.com/cosmos/cosmos-sdk/version.Commit=${{ env.GITHUB_SHA }}"
           sha256sum: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CHAINNET?=testnet # Options; localnet, testnet, chaosnet ,mainnet
+CHAINNET?=betanet
 BINARY?=sifnoded
 GOBIN?=${GOPATH}/bin
 NOW=$(shell date +'%Y-%m-%d_%T')
@@ -9,25 +9,13 @@ HTTPS_GIT := https://github.com/sifchain/sifnode.git
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 
-ifeq (mainnet,${CHAINNET})
-	BUILD_TAGS=mainnet
-else
-	BUILD_TAGS=testnet
-endif
-
-whitespace :=
-whitespace += $(whitespace)
-comma := ,
-build_tags_comma_sep := $(subst $(whitespace),$(comma),$(BUILD_TAGS))
-
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=sifchain \
 		  -X github.com/cosmos/cosmos-sdk/version.ServerName=sifnoded \
 		  -X github.com/cosmos/cosmos-sdk/version.ClientName=sifnoded \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
-		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
+		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT)
 
-BUILD_FLAGS := -ldflags '$(ldflags)' -tags ${BUILD_TAGS}
+BUILD_FLAGS := -ldflags '$(ldflags)'
 
 BINARIES=./cmd/sifnoded ./cmd/sifgen ./cmd/ebrelayer
 
@@ -35,7 +23,6 @@ all: lint install
 
 build-config:
 	echo $(CHAINNET)
-	echo $(BUILD_TAGS)
 	echo $(BUILD_FLAGS)
 
 init:


### PR DESCRIPTION
Includes:

* No longer prefix builds by the network (not necessary).
* Updated the release action to correctly set `ldflags`.
* Cleanup of the `sifnode` Makefile.