### PR TITLE
Remove invalid/broken commands for integration tests

### DIFF
--- a/test/integration/setup_sifchain.sh
+++ b/test/integration/setup_sifchain.sh
@@ -47,6 +47,4 @@ nohup $TEST_INTEGRATION_DIR/sifchain_start_daemon.sh < /dev/null > $SIFNODED_LOG
 # we don't have a great way to make sure sifchain itself has started
 sleep 10
 set_persistant_env_var SIFNODED_PID $! $envexportfile
-nohup sifnoded rest-server --laddr tcp://0.0.0.0:1317 < /dev/null > $datadir/logs/restserver.log 2>&1 &
-set_persistant_env_var REST_SERVER_PID $! $envexportfile
 bash $TEST_INTEGRATION_DIR/sifchain_start_ebrelayer.sh

--- a/test/integration/sifchain_start_daemon.sh
+++ b/test/integration/sifchain_start_daemon.sh
@@ -11,9 +11,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 . $(SCRIPT_DIR)/vagrantenv.sh
 . ${TEST_INTEGRATION_DIR}/shell_utilities.sh
 
-whitelisted_validator=$(yes $VALIDATOR1_PASSWORD | sifnoded keys show --keyring-backend file -a --bech val $MONIKER --home $CHAINDIR/.sifnoded)
-echo $0: whitelisted validator $whitelisted_validator
-sifnoded add-genesis-validators $whitelisted_validator --home $CHAINDIR/.sifnoded
 # need a new account to be the administrator
 adminuser=$(yes | sifnoded keys add sifnodeadmin --keyring-backend test --output json 2>&1 | jq -r .address)
 #{"name":"fnord","type":"local","address":"sif10ckfjtdmk9zkcs9fhl0h260xsj6kvg7esmyqrw","pubkey":"sifpub1addwnpepqtd7ysjyu9aynhemqe9sanmlest8y6dvg24aqzknfmp2ppp7cmxlkc7y8lz","mnemonic":"exact below syrup slender party witness already lamp inform dash impose ginger sauce shift tag humble awkward spawn blue flower lab census gold girl"}


### PR DESCRIPTION
Minor cleanup, these commands were not working anyway (they were failing silently).
I checked that removing them has no effect on any integration tests.
Already blessed by @banshee.