### PR TITLE
removing multiLock() in favor of multiLockBurn()

### DIFF
--- a/smart-contracts/contracts/BridgeBank/BridgeBank.sol
+++ b/smart-contracts/contracts/BridgeBank/BridgeBank.sol
@@ -486,37 +486,6 @@ contract BridgeBank is BankStorage, CosmosBank, EthereumWhiteList, CosmosWhiteLi
   }
 
   /**
-   * @notice Locks multiple tokens in the bridge contract in a single tx
-   * @dev This is used to handle the case where the user is sending tokens
-   * @param recipient Bytes representation of destination address
-   * @param token Token address
-   * @param amount Value of deposit
-   */
-  function multiLock(
-    bytes[] calldata recipient,
-    address[] calldata token,
-    uint256[] calldata amount
-  ) external whenNotPaused {
-    require(recipient.length == token.length, "M_P");
-    require(token.length == amount.length, "M_P");
-
-    // use intermediate lock burn nonce to distinguish between different lock calls
-    // this alows us to track the lock calls in the logs
-    // and to prevent double locking
-    // (i.e. if a user calls lock twice with the same amount, we don't want to lock twice)
-    // This pattern of using the intermediate value will save us gas
-    // by utilizing the stack for all intermediate values
-    uint256 intermediateLockBurnNonce = lockBurnNonce;
-
-    for (uint256 i = 0; i < recipient.length; i++) {
-      intermediateLockBurnNonce++;
-
-      _lockTokens(recipient[i], token[i], amount[i], intermediateLockBurnNonce);
-    }
-    lockBurnNonce = intermediateLockBurnNonce;
-  }
-
-  /**
    * @notice Locks or burns multiple tokens in the bridge contract in a single tx
    * @param recipient Bytes representation of destination address
    * @param token Token address

--- a/smart-contracts/test/test_bridgeBankLock.js
+++ b/smart-contracts/test/test_bridgeBankLock.js
@@ -2,10 +2,10 @@ const Web3Utils = require("web3-utils");
 const web3 = require("web3");
 const BigNumber = web3.BigNumber;
 
-const { ethers } = require("hardhat");
-const { use, expect } = require("chai");
-const { solidity } = require("ethereum-waffle");
-const { setup } = require("./helpers/testFixture");
+const {ethers} = require("hardhat");
+const {use, expect} = require("chai");
+const {solidity} = require("ethereum-waffle");
+const {setup} = require("./helpers/testFixture");
 
 require("chai").use(require("chai-as-promised")).use(require("chai-bignumber")(BigNumber)).should();
 
@@ -166,13 +166,18 @@ describe("Test Bridge Bank", function () {
   describe("Multi Lock ERC20 Tokens", function () {
     it("should allow user to multi-lock ERC20 tokens", async function () {
       // Attempt to lock tokens
-      await state.bridgeBank
+      const tx = await state.bridgeBank
         .connect(userOne)
-        .multiLock(
+        .multiLockBurn(
           [state.sender, state.sender, state.sender],
           [state.token1.address, state.token2.address, state.token3.address],
-          [state.amount, state.amount, state.amount]
+          [state.amount, state.amount, state.amount],
+          [false, false, false]
         );
+
+      const receipt = await tx.wait();
+      const sum = Number(receipt.gasUsed);
+      console.log(`GAS: ${sum}`);
 
       // Confirm that the user has been minted the correct token
       let afterUserBalance = Number(await state.token1.balanceOf(userOne.address));
@@ -194,10 +199,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.rejectedWith("Address is blocklisted");
 
@@ -369,10 +375,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("transfer amount exceeds allowance");
 
@@ -392,10 +399,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount]
+            [state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("M_P");
     });
@@ -405,10 +413,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender],
             [state.token1.address, state.token2.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("M_P");
     });
@@ -418,10 +427,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("M_P");
     });
@@ -431,10 +441,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender + "ee", state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("INV_SIF_ADDR");
     });
@@ -445,10 +456,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("Pausable: paused");
     });
@@ -458,7 +470,7 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender, state.sender],
             [
               state.token1.address,
@@ -466,9 +478,10 @@ describe("Test Bridge Bank", function () {
               state.token3.address,
               state.constants.zeroAddress,
             ],
-            [state.amount, state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount, state.amount],
+            [false, false, false, false]
           ),
-        { value: 100 }
+        {value: 100}
       ).to.be.revertedWith("Address: call to non-contract");
     });
 
@@ -610,10 +623,11 @@ describe("Test Bridge Bank", function () {
       await expect(
         state.bridgeBank
           .connect(userOne)
-          .multiLock(
+          .multiLockBurn(
             [state.sender, state.sender, state.sender],
             [state.token1.address, state.token2.address, state.token3.address],
-            [state.amount, state.amount, state.amount]
+            [state.amount, state.amount, state.amount],
+            [false, false, false]
           )
       ).to.be.revertedWith("Only token not in cosmos whitelist can be locked");
     });

--- a/smart-contracts/test/test_bridgeBankLock.js
+++ b/smart-contracts/test/test_bridgeBankLock.js
@@ -166,7 +166,7 @@ describe("Test Bridge Bank", function () {
   describe("Multi Lock ERC20 Tokens", function () {
     it("should allow user to multi-lock ERC20 tokens", async function () {
       // Attempt to lock tokens
-      const tx = await state.bridgeBank
+      await state.bridgeBank
         .connect(userOne)
         .multiLockBurn(
           [state.sender, state.sender, state.sender],
@@ -174,10 +174,6 @@ describe("Test Bridge Bank", function () {
           [state.amount, state.amount, state.amount],
           [false, false, false]
         );
-
-      const receipt = await tx.wait();
-      const sum = Number(receipt.gasUsed);
-      console.log(`GAS: ${sum}`);
 
       // Confirm that the user has been minted the correct token
       let afterUserBalance = Number(await state.token1.balanceOf(userOne.address));


### PR DESCRIPTION
- Removed the function `multiLock` from BridgeBank
- Changed all tests that used to call `multiLock` so that they now call `multiLockBurn`, maintaining everything else as was.