### PR TITLE
Marsifi/clp min threshold param

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,111 +46,17 @@ require (
 )
 
 require (
-	filippo.io/edwards25519 v1.0.0-beta.2 // indirect
-	github.com/99designs/keyring v1.1.6 // indirect
-	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
-	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
-	github.com/Workiva/go-datastructures v1.0.52 // indirect
-	github.com/armon/go-metrics v0.3.9 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bgentry/speakeasy v0.1.0 // indirect
-	github.com/btcsuite/btcd v0.22.0-beta // indirect
-	github.com/cespare/xxhash v1.1.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/coinbase/rosetta-sdk-go v0.6.10 // indirect
-	github.com/confio/ics23/go v0.6.6 // indirect
-	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/iavl v0.17.2 // indirect
-	github.com/cosmos/ledger-cosmos-go v0.11.1 // indirect
-	github.com/cosmos/ledger-go v0.9.2 // indirect
-	github.com/danieljoos/wincred v1.0.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
-	github.com/dgraph-io/badger/v2 v2.2007.2 // indirect
-	github.com/dgraph-io/ristretto v0.0.3 // indirect
-	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b // indirect
-	github.com/enigmampc/btcutil v1.0.3-0.20200723161021-e2fb6adb2a25 // indirect
-	github.com/felixge/httpsnoop v1.0.1 // indirect
-	github.com/go-kit/kit v0.10.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.0 // indirect
-	github.com/go-ole/go-ole v1.2.5 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/gogo/gateway v1.1.0 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/btree v1.0.0 // indirect
-	github.com/google/orderedcode v0.0.1 // indirect
-	github.com/gorilla/handlers v1.5.1 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
-	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
-	github.com/gtank/merlin v0.1.1 // indirect
-	github.com/gtank/ristretto255 v0.1.2 // indirect
-	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
-	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87 // indirect
 	github.com/improbable-eng/grpc-web v0.14.1 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jmhodges/levigo v1.0.0 // indirect
-	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d // indirect
-	github.com/klauspost/compress v1.11.7 // indirect
-	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
-	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 // indirect
-	github.com/minio/highwayhash v1.0.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mtibben/percent v0.2.1 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
-	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.29.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
-	github.com/regen-network/cosmos-proto v0.3.1 // indirect
-	github.com/rs/cors v1.7.0 // indirect
-	github.com/rs/zerolog v1.23.0 // indirect
-	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
-	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
-	github.com/spf13/afero v1.6.0 // indirect
-	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
-	github.com/tendermint/btcd v0.1.1 // indirect
-	github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 // indirect
-	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.7 // indirect
-	github.com/tklauser/numcpus v0.2.3 // indirect
-	github.com/zondax/hid v0.9.0 // indirect
-	go.etcd.io/bbolt v1.3.5 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f // indirect
-	golang.org/x/sys v0.0.0-20210903071746-97244b99971b // indirect
-	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
-	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	nhooyr.io/websocket v1.8.6 // indirect
 )
 
 require (
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/lib/pq v1.10.2 // indirect
-	github.com/mitchellh/mapstructure v1.4.2 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	gopkg.in/ini.v1 v1.63.2 // indirect
 )
 
 replace (

--- a/x/clp/keeper/keeper_test.go
+++ b/x/clp/keeper/keeper_test.go
@@ -23,7 +23,7 @@ func TestKeeper_Errors(t *testing.T) {
 	ctx, app := test.CreateTestAppClp(false)
 	clpKeeper := app.ClpKeeper
 	num := clpKeeper.GetMinCreatePoolThreshold(ctx)
-	assert.Equal(t, num, uint64(types.DefaultMinCreatePoolThreshold))
+	assert.Equal(t, num, types.DefaultMinCreatePoolThreshold)
 	_ = clpKeeper.GetParams(ctx)
 	_ = clpKeeper.Logger(ctx)
 	pool.ExternalAsset.Symbol = ""

--- a/x/clp/keeper/keeper_test.go
+++ b/x/clp/keeper/keeper_test.go
@@ -23,7 +23,7 @@ func TestKeeper_Errors(t *testing.T) {
 	ctx, app := test.CreateTestAppClp(false)
 	clpKeeper := app.ClpKeeper
 	num := clpKeeper.GetMinCreatePoolThreshold(ctx)
-	assert.Equal(t, num, uint64(100))
+	assert.Equal(t, num, uint64(types.DefaultMinCreatePoolThreshold))
 	_ = clpKeeper.GetParams(ctx)
 	_ = clpKeeper.Logger(ctx)
 	pool.ExternalAsset.Symbol = ""

--- a/x/clp/keeper/msg_server.go
+++ b/x/clp/keeper/msg_server.go
@@ -39,7 +39,8 @@ func (k msgServer) DecommissionPool(goCtx context.Context, msg *types.MsgDecommi
 	if !k.Keeper.ValidateAddress(ctx, addAddr) {
 		return nil, sdkerrors.Wrap(types.ErrInvalid, "user does not have permission to decommission pool")
 	}
-	if pool.NativeAssetBalance.GTE(sdk.NewUintFromString(types.PoolThrehold)) {
+	minThreshold := sdk.NewUint(k.GetParams(ctx).MinCreatePoolThreshold)
+	if pool.NativeAssetBalance.GTE(minThreshold) {
 		return nil, types.ErrBalanceTooHigh
 	}
 	// Get all LP's for the pool
@@ -349,9 +350,10 @@ func (k msgServer) RemoveLiquidity(goCtx context.Context, msg *types.MsgRemoveLi
 
 func (k msgServer) CreatePool(goCtx context.Context, msg *types.MsgCreatePool) (*types.MsgCreatePoolResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
 	// Verify min threshold
-	MinThreshold := sdk.NewUintFromString(types.PoolThrehold)
-	if msg.NativeAssetAmount.LT(MinThreshold) { // Need to verify
+	minThreshold := sdk.NewUint(k.GetParams(ctx).MinCreatePoolThreshold)
+	if msg.NativeAssetAmount.LT(minThreshold) {
 		return nil, types.ErrTotalAmountTooLow
 	}
 	registry := k.tokenRegistryKeeper.GetRegistry(ctx)

--- a/x/clp/types/genesis_test.go
+++ b/x/clp/types/genesis_test.go
@@ -8,11 +8,11 @@ import (
 
 func Test_NewGenesisState(t *testing.T) {
 	genesisState := NewGenesisState(DefaultParams())
-	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, uint64(100))
+	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, uint64(DefaultParams().MinCreatePoolThreshold))
 }
 
 func Test_DefaultGenesisState(t *testing.T) {
 	genesisState := DefaultGenesisState()
-	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, uint64(100))
+	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, uint64(DefaultParams().MinCreatePoolThreshold))
 	assert.Equal(t, genesisState.AddressWhitelist, []string{"cosmos1ny48eeuk4dm9f63dy0lwfgjhnvud9yvt8tcaat"})
 }

--- a/x/clp/types/genesis_test.go
+++ b/x/clp/types/genesis_test.go
@@ -8,11 +8,11 @@ import (
 
 func Test_NewGenesisState(t *testing.T) {
 	genesisState := NewGenesisState(DefaultParams())
-	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, uint64(DefaultParams().MinCreatePoolThreshold))
+	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, DefaultParams().MinCreatePoolThreshold)
 }
 
 func Test_DefaultGenesisState(t *testing.T) {
 	genesisState := DefaultGenesisState()
-	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, uint64(DefaultParams().MinCreatePoolThreshold))
+	assert.Equal(t, genesisState.Params.MinCreatePoolThreshold, DefaultParams().MinCreatePoolThreshold)
 	assert.Equal(t, genesisState.AddressWhitelist, []string{"cosmos1ny48eeuk4dm9f63dy0lwfgjhnvud9yvt8tcaat"})
 }

--- a/x/clp/types/keys.go
+++ b/x/clp/types/keys.go
@@ -18,7 +18,6 @@ const (
 	QuerierRoute = ModuleName
 
 	NativeSymbol      = "rowan"
-	PoolThrehold      = "1000000000000000000"
 	PoolUnitsMinValue = "1000000000"
 
 	MaxSymbolLength = 71

--- a/x/clp/types/params.go
+++ b/x/clp/types/params.go
@@ -10,7 +10,7 @@ import (
 // Default parameter namespace
 const (
 	DefaultParamspace                    = ModuleName
-	DefaultMinCreatePoolThreshold uint64 = 100
+	DefaultMinCreatePoolThreshold uint64 = 1000000000000000000
 )
 
 // Parameter store keys


### PR DESCRIPTION
The CLP module was using a hardcoded value for MinThreshold when performing checks before creating a pool.

There was some discrepancy between this hardcoded value and the module parameter `MinCreatePoolThreshold`.

This PR updates the CLP module to use the value from the parameter, not the the hardcoded value.