### PR TITLE
Fixes decimal precisions or USDT and WBTC and adds IBCIMPORT to all ETH tokens

### DIFF
--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/cbat.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/cbat.json
@@ -15,7 +15,8 @@
       "transfer_limit": "",
       "permissions": [
         "CLP",
-        "IBCEXPORT"
+        "IBCEXPORT",
+        "IBCIMPORT"
       ],
       "unit_denom": "",
       "ibc_counterparty_denom": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/ceth.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/ceth.json
@@ -15,7 +15,8 @@
       "transfer_limit": "",
       "permissions": [
         "CLP",
-        "IBCEXPORT"
+        "IBCEXPORT",
+	"IBCIMPORT"
       ],
       "unit_denom": "",
       "ibc_counterparty_denom": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/clink.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/clink.json
@@ -15,7 +15,8 @@
       "transfer_limit": "",
       "permissions": [
         "CLP",
-        "IBCEXPORT"
+        "IBCEXPORT",
+	"IBCIMPORT"
       ],
       "unit_denom": "",
       "ibc_counterparty_denom": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/cusdt.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/cusdt.json
@@ -15,7 +15,8 @@
       "transfer_limit": "",
       "permissions": [
         "CLP",
-        "IBCEXPORT"
+        "IBCEXPORT",
+	"IBCIMPORT"
       ],
       "unit_denom": "",
       "ibc_counterparty_denom": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/cusdt.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/cusdt.json
@@ -1,7 +1,7 @@
 {
   "entries": [
     {
-      "decimals": "18",
+      "decimals": "6",
       "denom": "cusdt",
       "base_denom": "cusdt",
       "path": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/cwbtc.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/cwbtc.json
@@ -1,7 +1,7 @@
 {
   "entries": [
     {
-      "decimals": "18",
+      "decimals": "8",
       "denom": "cwbtc",
       "base_denom": "cwbtc",
       "path": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/cwbtc.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/cwbtc.json
@@ -15,7 +15,8 @@
       "transfer_limit": "",
       "permissions": [
         "CLP",
-        "IBCEXPORT"
+        "IBCEXPORT",
+	"IBCIMPORT"
       ],
       "unit_denom": "",
       "ibc_counterparty_denom": "",

--- a/scripts/ibc/tokenregistration/sifchain-testnet-1/czrx.json
+++ b/scripts/ibc/tokenregistration/sifchain-testnet-1/czrx.json
@@ -15,7 +15,8 @@
       "transfer_limit": "",
       "permissions": [
         "CLP",
-        "IBCEXPORT"
+        "IBCEXPORT",
+	"IBCIMPORT"
       ],
       "unit_denom": "",
       "ibc_counterparty_denom": "",


### PR DESCRIPTION
Fixes decimal precisions on testnet for 

- [x] USDT
- [x] WBTC

Added IBCIMPORT permission for 
- [x] USDT
- [x] WBTC
- [x] ETH
- [x] LINK
- [x] ZRX
- [x] BAT