### PR TITLE
Feature/margin 1 addup amount existing mtp

### DIFF
--- a/x/margin/keeper/msg_server_test.go
+++ b/x/margin/keeper/msg_server_test.go
@@ -597,7 +597,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(162001036806635562, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999983074),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -650,7 +650,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(164397974616952719, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999981994),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -703,7 +703,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(500000000000000000, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999981994),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -762,7 +762,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(163049681237873180, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999982598),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999982598),
@@ -815,7 +815,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(163049681237873180, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999982597),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -868,7 +868,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(500000000000000000, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999981994),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -927,7 +927,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(163039047851960545, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999982602),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999935000),
@@ -980,7 +980,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(161995788109509153, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999998307),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -1033,7 +1033,7 @@ func TestKeeper_EC(t *testing.T) {
 							mtpHealth:                                sdk.NewDecWithPrec(500000000000000000, 18),
 						},
 						{
-							chunk:                                    sdk.NewUint(55),
+							chunk:                                    sdk.NewUint(50),
 							signerNativeAssetBalanceAfterOpenLong:    sdk.NewUint(99999999981994),
 							signerExternalAssetBalanceAfterOpenLong:  sdk.NewUint(1000000000000000),
 							signerNativeAssetBalanceAfterCloseLong:   sdk.NewUint(99999999983074),
@@ -1228,4 +1228,95 @@ func TestKeeper_EC(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestKeeper_AddUpExistingMTP(t *testing.T) {
+	nativeAsset := clptypes.NativeSymbol
+	externalAsset := clptypes.Asset{Symbol: "xxx"}
+
+	ctx, app := test.CreateTestAppMargin(false)
+	marginKeeper := app.MarginKeeper
+
+	app.TokenRegistryKeeper.SetToken(ctx, &tokenregistrytypes.RegistryEntry{
+		Denom:       externalAsset.Symbol,
+		Decimals:    18,
+		Permissions: []tokenregistrytypes.Permission{tokenregistrytypes.Permission_CLP},
+	})
+
+	msgServer := keeper.NewMsgServerImpl(marginKeeper)
+
+	pool := clptypes.Pool{
+		ExternalAsset:        &externalAsset,
+		NativeAssetBalance:   sdk.NewUint(1000000000000),
+		ExternalAssetBalance: sdk.NewUint(1000000000000),
+		NativeCustody:        sdk.ZeroUint(),
+		ExternalCustody:      sdk.ZeroUint(),
+		NativeLiabilities:    sdk.ZeroUint(),
+		ExternalLiabilities:  sdk.ZeroUint(),
+		PoolUnits:            sdk.ZeroUint(),
+		Health:               sdk.ZeroDec(),
+		InterestRate:         sdk.NewDecWithPrec(1, 1),
+	}
+
+	marginKeeper.SetEnabledPools(ctx, []string{externalAsset.Symbol})
+	marginKeeper.ClpKeeper().SetPool(ctx, &pool)
+
+	nativeCoin := sdk.NewCoin(nativeAsset, sdk.Int(sdk.NewUint(1000000000000)))
+	externalCoin := sdk.NewCoin(externalAsset.Symbol, sdk.Int(sdk.NewUint(1000000000000)))
+	err := app.BankKeeper.MintCoins(ctx, clptypes.ModuleName, sdk.NewCoins(nativeCoin, externalCoin))
+	require.Nil(t, err)
+
+	signer := clptest.GenerateAddress(clptest.AddressKey1)
+	nativeCoin = sdk.NewCoin(nativeAsset, sdk.Int(sdk.NewUint(100000000000000)))
+	externalCoin = sdk.NewCoin(externalAsset.Symbol, sdk.Int(sdk.NewUint(1000000000000000)))
+	err = sifapp.AddCoinsToAccount(types.ModuleName, app.BankKeeper, ctx, signer, sdk.NewCoins(nativeCoin, externalCoin))
+	require.Nil(t, err)
+
+	msg1 := types.MsgOpenLong{
+		Signer:           signer.String(),
+		CollateralAsset:  nativeAsset,
+		CollateralAmount: sdk.NewUint(1000),
+		BorrowAsset:      externalAsset.Symbol,
+	}
+
+	_, openLongError := msgServer.OpenLong(sdk.WrapSDKContext(ctx), &msg1)
+	require.NoError(t, openLongError)
+
+	openLongExpectedMTP := types.MTP{
+		Address:          signer.String(),
+		CollateralAsset:  nativeAsset,
+		CollateralAmount: sdk.NewUint(1000),
+		LiabilitiesP:     sdk.NewUint(1000),
+		LiabilitiesI:     sdk.ZeroUint(),
+		CustodyAsset:     externalAsset.Symbol,
+		CustodyAmount:    sdk.NewUint(4000),
+		Leverage:         sdk.NewUint(1),
+		MtpHealth:        sdk.NewDecWithPrec(1, 1),
+	}
+	openLongMTP, _ := marginKeeper.GetMTP(ctx, nativeAsset, externalAsset.Symbol, signer.String())
+	require.Equal(t, openLongExpectedMTP, openLongMTP)
+
+	msg2 := types.MsgOpenLong{
+		Signer:           signer.String(),
+		CollateralAsset:  nativeAsset,
+		CollateralAmount: sdk.NewUint(500),
+		BorrowAsset:      externalAsset.Symbol,
+	}
+
+	_, openLongError = msgServer.OpenLong(sdk.WrapSDKContext(ctx), &msg2)
+	require.NoError(t, openLongError)
+
+	openLongExpectedMTP = types.MTP{
+		Address:          signer.String(),
+		CollateralAsset:  nativeAsset,
+		CollateralAmount: sdk.NewUint(1500),
+		LiabilitiesP:     sdk.NewUint(1500),
+		LiabilitiesI:     sdk.ZeroUint(),
+		CustodyAsset:     externalAsset.Symbol,
+		CustodyAmount:    sdk.NewUint(6000),
+		Leverage:         sdk.NewUint(1),
+		MtpHealth:        sdk.NewDecWithPrec(1, 1),
+	}
+	openLongMTP, _ = marginKeeper.GetMTP(ctx, nativeAsset, externalAsset.Symbol, signer.String())
+	require.Equal(t, openLongExpectedMTP, openLongMTP)
 }


### PR DESCRIPTION
@AustinoBombino @timlind you can find here the use case where the user adds up a certain amount to an existing asset long MTP

We had some discussions over having several MTPs created for the same asset, some I am not quite sure if I should rather except to a list of MTPs for a given asset rather than getting a single one.

So far the test obviously overrides the existing MTP for the used asset.