### PR TITLE
remove register all

### DIFF
--- a/smart-contracts/src/devenv/sifnoded.ts
+++ b/smart-contracts/src/devenv/sifnoded.ts
@@ -175,10 +175,11 @@ export class SifnodedRunner extends ShellCommand<SifnodedResults> {
     // Must wait for sifnode to fully start first
     await waitForSifAccount(networkConfig[0].address, this.sifnodedCommand)
     const registryPath = path.resolve(__dirname, "./", "registry.json")
-    ChildProcess.execSync(
-      `${this.sifnodedCommand} tx tokenregistry register-all ${registryPath} --home ${homeDir} --gas-prices 0.5rowan --from ${sifnodedAdminAddress.name} --yes --keyring-backend test --chain-id ${this.chainId} --node tcp://0.0.0.0:26657`,
+    const registryResult = ChildProcess.execSync(
+      `${this.sifnodedCommand} tx tokenregistry set-registry ${registryPath} --home ${homeDir} --gas-prices 0.5rowan --from ${sifnodedAdminAddress.name} --yes --keyring-backend test --chain-id ${this.chainId} --node tcp://0.0.0.0:26657`,
       {encoding: "utf8"}
     ).trim()
+    console.log("registryResult as ", registryResult)
 
     // We need wait for last tx wrapped up in block, otherwise we could get a wrong sequence
     await sleep(10000)

--- a/test/integration/framework/sifchain.py
+++ b/test/integration/framework/sifchain.py
@@ -135,7 +135,7 @@ class Sifnoded:
     def peggy2_token_registry_register_all(self, registry_path, gas_prices, gas_adjustment, from_account,
         chain_id
     ):
-        args = ["tx", "tokenregistry", "register-all", registry_path, "--gas-prices", sif_format_amount(*gas_prices),
+        args = ["tx", "tokenregistry", "set-registry", registry_path, "--gas-prices", sif_format_amount(*gas_prices),
             "--gas-adjustment", str(gas_adjustment), "--from", from_account, "--chain-id", chain_id, "--yes"]
         res = self.sifnoded_exec(args, keyring_backend=self.keyring_backend, sifnoded_home=self.home)
         return [json.loads(x) for x in stdout(res).splitlines()]

--- a/x/tokenregistry/client/cli/tx.go
+++ b/x/tokenregistry/client/cli/tx.go
@@ -21,49 +21,8 @@ func GetTxCmd() *cobra.Command {
 		GetCmdRegister(),
 		GetCmdDeregister(),
 		GetCmdAddIBCTokenMetadata(),
-		GetCmdRegisterAll(),
-		GetCmdDeregisterAll(),
 		GetCmdSetRegistry(),
 	)
-	return cmd
-}
-
-func GetCmdRegisterAll() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "register-all [registry.json]",
-		Short: "Add / update tokens on the registry",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-			err = cobra.ExactArgs(1)(cmd, args)
-			if err != nil {
-				return err
-			}
-			registry, err := whitelistutils.ParseDenoms(clientCtx.Codec, args[0])
-			if err != nil {
-				return err
-			} else if len(registry.Entries) < 1 {
-				return errors.New("at least one token entry must be specified in input file")
-			}
-			for _, entry := range registry.Entries {
-				msg := types.MsgRegister{
-					From:  clientCtx.GetFromAddress().String(),
-					Entry: entry,
-				}
-				if err := msg.ValidateBasic(); err != nil {
-					return err
-				}
-				err := tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		},
-	}
-	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
 
@@ -116,9 +75,8 @@ func GetCmdSetRegistry() *cobra.Command {
 			registry, err := whitelistutils.ParseDenoms(clientCtx.Codec, args[0])
 			if err != nil {
 				return err
-			} else if len(registry.Entries) != 1 {
-				return errors.New("exactly one token entry must be specified in input file")
 			}
+
 			msg := types.MsgSetRegistry{
 				From:     clientCtx.GetFromAddress().String(),
 				Registry: &registry,
@@ -154,46 +112,6 @@ func GetCmdDeregister() *cobra.Command {
 				return err
 			}
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
-		},
-	}
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
-}
-
-func GetCmdDeregisterAll() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "deregister-all [registry.json]",
-		Short: "Remove all tokens listed in registry.json from the registry",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-			err = cobra.ExactArgs(1)(cmd, args)
-			if err != nil {
-				return err
-			}
-			registry, err := whitelistutils.ParseDenoms(clientCtx.Codec, args[0])
-			if err != nil {
-				return err
-			} else if len(registry.Entries) < 1 {
-				return errors.New("at least one token entry must be specified in input file")
-			}
-			for _, entry := range registry.Entries {
-				msg := types.MsgDeregister{
-					From:  clientCtx.GetFromAddress().String(),
-					Denom: entry.Denom,
-				}
-				if err := msg.ValidateBasic(); err != nil {
-					return err
-				}
-				err := tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
-
-				if err != nil {
-					return err
-				}
-			}
-			return nil
 		},
 	}
 	flags.AddTxFlagsToCmd(cmd)


### PR DESCRIPTION
The register-all doesn't work in the future/peggy2 branch, it generates multiple TXs according to items number in the json file. we can see the wrong sequence issue for second tx and following. 
The PR remove the interface and update set registry, also update integration test.