### PR TITLE
In multiLockBurn, update lockBurnNonce before we do any external calls.

### DIFF
--- a/smart-contracts/contracts/BridgeBank/BridgeBank.sol
+++ b/smart-contracts/contracts/BridgeBank/BridgeBank.sol
@@ -566,6 +566,10 @@ contract BridgeBank is BankStorage, CosmosBank, EthereumWhiteList, CosmosWhiteLi
         _lockTokens(recipient[i], token[i], amount[i], startingLockBurnNonce + i);
       }
     }
+
+    // If we get any reentrant calls from the _{burn,lock}Tokens functions, 
+    // make sure that lockBurnNonce is what we expect it to be.
+    require(lockBurnNonce == startingLockBurnNonce - 1 + recipientLength, "M_P");
   }
 
   /**

--- a/smart-contracts/contracts/BridgeBank/BridgeBank.sol
+++ b/smart-contracts/contracts/BridgeBank/BridgeBank.sol
@@ -462,7 +462,7 @@ contract BridgeBank is BankStorage, CosmosBank, EthereumWhiteList, CosmosWhiteLi
    *      such that tokens which charge fees on transfer are accurately represented.
    * @param token The bridgeToken's address
    * @param amount The amount of bridgeToken's to transfer to the bridgebank
-   * @return The balance that was transfered as reported by the getBalance command   
+   * @return The balance that was transfered as reported by the getBalance command
    */
   function transferBalance(address token, uint256 amount) private returns (uint256) {
     //The interface of the ERC20 token to interact with
@@ -478,10 +478,10 @@ contract BridgeBank is BankStorage, CosmosBank, EthereumWhiteList, CosmosWhiteLi
     uint256 newBalance = getBalance(token);
 
     //Calculate the total amount transfered from the newbalance vs the old balance
-    //Since this contract uses solidity 0.8+ overflows from bad acting tokens should 
+    //Since this contract uses solidity 0.8+ overflows from bad acting tokens should
     //revert.
     uint256 transferedAmount = newBalance - oldBalance;
-    
+
     return transferedAmount;
   }
 
@@ -548,18 +548,24 @@ contract BridgeBank is BankStorage, CosmosBank, EthereumWhiteList, CosmosWhiteLi
     require(token.length == amount.length, "M_P");
     require(token.length == isBurn.length, "M_P");
 
-    uint256 intermediateLockBurnNonce = lockBurnNonce;
+    uint256 recipientLength = recipient.length;
 
-    for (uint256 i = 0; i < recipient.length; i++) {
-      intermediateLockBurnNonce++;
+    // lockBurnNonce contains the previous nonce that was
+    // sent in the LogLock/LogBurn, so the first one we send
+    // should be lockBurnNonce + 1
+    uint256 startingLockBurnNonce = lockBurnNonce + 1;
 
+    // This is equivalent of lockBurnNonce = lockBurnNonce + recipientLength,
+    // but it avoids a read of storage
+    lockBurnNonce = startingLockBurnNonce - 1 + recipientLength;
+
+    for (uint256 i = 0; i < recipientLength; ++i) {
       if (isBurn[i]) {
-        _burnTokens(recipient[i], token[i], amount[i], intermediateLockBurnNonce);
+        _burnTokens(recipient[i], token[i], amount[i], startingLockBurnNonce + i);
       } else {
-        _lockTokens(recipient[i], token[i], amount[i], intermediateLockBurnNonce);
+        _lockTokens(recipient[i], token[i], amount[i], startingLockBurnNonce + i);
       }
     }
-    lockBurnNonce = intermediateLockBurnNonce;
   }
 
   /**

--- a/smart-contracts/scripts/watcher.ts
+++ b/smart-contracts/scripts/watcher.ts
@@ -13,7 +13,7 @@ import { EvmStateTransition, toEvmRelayerEvent } from "../src/watcher/ebrelayer"
 import { sifwatch } from "../src/watcher/watcher"
 
 async function main() {
-  const evmRelayerEvents = sifwatch("/tmp/sifnode/evmrelayer.log")
+  const evmRelayerEvents = sifwatch("/tmp/sifnode/relayer.log")
 
   evmRelayerEvents.subscribe({
     next: (x) => {

--- a/smart-contracts/src/contractSupport.ts
+++ b/smart-contracts/src/contractSupport.ts
@@ -23,7 +23,7 @@ export async function getContractFromTruffleArtifact<T extends BaseContract>(
   const truffle = require("@truffle/contract")
   const truffleContract = (truffle as any)(parsedArtifactContents)
   const contractData = truffleContract.networks[chainId]
-  const ethersContract = await hre.ethers.getContractAt(truffleContract.abi, contractData.address)
+  const ethersContract: BaseContract = await hre.ethers.getContractAt(truffleContract.abi, contractData.address)
   return ethersContract as T
 }
 

--- a/smart-contracts/src/devenv/ebrelayer.ts
+++ b/smart-contracts/src/devenv/ebrelayer.ts
@@ -120,7 +120,7 @@ export class RelayerRunner extends ShellCommand<EbrelayerResults> {
     readonly ebrelayerDB = `levelDB.db`,
     readonly relayerdbPath = "./relayerdb",
     readonly symbolTranslatorFile = "../test/integration/config/symbol_translator.json",
-    readonly logFile = "/tmp/sifnode/evmrelayer.log"
+    readonly logFile = "/tmp/sifnode/relayer.log"
   ) {
     super()
     this.output = new Promise<EbrelayerResults>((res, rej) => {

--- a/smart-contracts/src/watcher/watcher.ts
+++ b/smart-contracts/src/watcher/watcher.ts
@@ -33,7 +33,6 @@ export function sifwatch(
   // TODO: Const?
   const observables: Observable<SifEvent>[] = new Array()
 
-  // const evmRelayerLines = readableStreamToObservable(fs.createReadStream("/tmp/sifnode/evmrelayer.log"))
   const evmRelayerLines = tailFileAsObservable(logs.evmrelayer)
   const evmRelayerEvents: Observable<EbRelayerEvent> = evmRelayerLines.pipe(
     map(jsonParseSimple),

--- a/smart-contracts/test/devenv/evm_lock_burn.ts
+++ b/smart-contracts/test/devenv/evm_lock_burn.ts
@@ -43,7 +43,7 @@ export async function executeLock(
  * @param sender Who is sending the ether to sifchain
  * @param sifchainRecipient What sifchain address is recieving the ERC20 tokens
  * @param tokenContract The ERC20 contract that is being bridged
- * @returns 
+ * @returns
  */
 export async function executeLock(
   contracts: DevEnvContracts,
@@ -85,7 +85,7 @@ export async function checkEvmLockState(
 ) {
   const [evmRelayerEvents, replayedEvents] = sifwatchReplayable(
     {
-      evmrelayer: "/tmp/sifnode/evmrelayer.log",
+      evmrelayer: "/tmp/sifnode/relayer.log",
       sifnoded: "/tmp/sifnode/sifnoded.log",
     },
     hardhat,

--- a/smart-contracts/test/devenv/sifnode_lock_burn.ts
+++ b/smart-contracts/test/devenv/sifnode_lock_burn.ts
@@ -31,7 +31,7 @@ export async function checkSifnodeBurnState(
 ) {
   const evmRelayerEvents: rxjs.Observable<SifEvent> = sifwatch(
     {
-      evmrelayer: "/tmp/sifnode/evmrelayer.log",
+      evmrelayer: "/tmp/sifnode/relayer.log",
       sifnoded: "/tmp/sifnode/sifnoded.log",
       witness: "/tmp/sifnode/witness.log",
     },

--- a/smart-contracts/test/test_bridgeBankLock.js
+++ b/smart-contracts/test/test_bridgeBankLock.js
@@ -198,6 +198,8 @@ describe("Test Bridge Bank", function () {
 
   describe("Multi Lock ERC20 Tokens", function () {
     it("should allow user to multi-lock ERC20 tokens", async function () {
+      const previousNonce = await state.bridgeBank.connect(userOne).lockBurnNonce();
+
       // Attempt to lock tokens
       await state.bridgeBank
         .connect(userOne)
@@ -207,6 +209,8 @@ describe("Test Bridge Bank", function () {
           [state.amount, state.amount, state.amount],
           [false, false, false]
         );
+
+      (await state.bridgeBank.connect(userOne).lockBurnNonce()).should.be.bignumber.equal(previousNonce.add(3));
 
       // Confirm that the user has been minted the correct token
       let afterUserBalance = Number(await state.token1.balanceOf(userOne.address));


### PR DESCRIPTION
Also avoid recalculating recipient.length on every pass through the loop