### PR TITLE
Add: Exclusion to codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -32,6 +32,8 @@ ignore:
   - "*.proto"
   - "*.md"
   - "*.rst"
+  - "*.json"
+  - "*.lock"
   - "**/test_common.go"
   - "**/test_helpers.go"
   - "**/module.go"


### PR DESCRIPTION
PR to make codecov not to inspect `*.lock` and `*.json` to save some time and resource.