### PR TITLE
prune in unlock request

### DIFF
--- a/x/clp/keeper/msg_server.go
+++ b/x/clp/keeper/msg_server.go
@@ -175,6 +175,9 @@ func (k msgServer) UnlockLiquidity(goCtx context.Context, request *types.MsgUnlo
 	if err != nil {
 		return nil, types.ErrLiquidityProviderDoesNotExist
 	}
+	// Prune unlocks
+	params := k.GetRewardsParams(ctx)
+	k.PruneUnlockRecords(ctx, &lp, params.LiquidityRemovalLockPeriod, params.LiquidityRemovalCancelPeriod)
 	totalUnlocks := sdk.ZeroUint()
 	for _, unlock := range lp.Unlocks {
 		totalUnlocks = totalUnlocks.Add(unlock.Units)


### PR DESCRIPTION
pruning during unlock fixes the linked issue, but I'm also seeing in testing that a removal request isn't clearing the expired unlock.

1. add liquidity 
2. submit an unlock for the full amount 
3. wait through lock period and cancel period
4. submit a remove for the full amount 

the unlock request doesn't get wiped