### PR TITLE
Load test: many denoms sif wallet

### DIFF
--- a/test/integration/framework/siftool
+++ b/test/integration/framework/siftool
@@ -13,8 +13,10 @@ import subprocess
 def execst(args, cwd=None):
     return subprocess.run(args, cwd=cwd, check=True, capture_output=False)
 
+
 def get_basedir():
     return os.path.abspath(os.path.join(os.path.normpath(os.path.dirname(__file__))))
+
 
 def init_venv(venv_dir, requirements_txt):
     execst(["python3", "-m", "venv", venv_dir])
@@ -22,6 +24,7 @@ def init_venv(venv_dir, requirements_txt):
     execst([venv_pip, "install", "--upgrade", "pip"])
     execst([venv_pip, "install", "wheel"])
     execst([venv_pip, "install", "-r", requirements_txt])
+
 
 def ensure_venv(venv_dir, requirements_txt, lock_file=None):
     def wrapped():
@@ -48,18 +51,21 @@ def load_main_module():
 
     ensure_venv(venv_dir, requirements_txt, lock_file=lock_file)
     venv_lib_dir = glob.glob(os.path.join(venv_dir, "lib", "python3.*"))[0]
-    sys.path = sys.path + [
+    paths = [
         os.path.join(base_dir, "src"),
         os.path.join(base_dir, "build/generated"),
         os.path.join(venv_lib_dir, "site-packages"),
-        os.path.join(project_root, "test", "integration"),  # For running integration tests in-process
     ]
+    paths_to_add = [p for p in paths if not any(os.path.realpath(p) == os.path.realpath(s) for s in sys.path)]
+    sys.path.extend(paths_to_add)
     import siftool.main as siftool_main
     return siftool_main
+
 
 def main(argv):
     main_module = load_main_module()
     main_module.main(argv)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/test/integration/framework/src/siftool/common.py
+++ b/test/integration/framework/src/siftool/common.py
@@ -82,7 +82,7 @@ def popen(args: Sequence[str], cwd: Optional[str] = None, env: Optional[Mapping[
 ) -> subprocess.Popen:
     if env:
         env = dict_merge(os.environ, env)
-    logging.debug(f"popen(): args={repr(args)}, cwd={repr(cwd)}")
+    log.debug(f"popen(): args={repr(args)}, cwd={repr(cwd)}")
     return subprocess.Popen(args, cwd=cwd, env=env, stdin=stdin, stdout=stdout, stderr=stderr, text=text)
 
 def dict_merge(*dicts, override=True):
@@ -108,6 +108,7 @@ def basic_logging_setup():
     logging.getLogger("eth").setLevel(logging.WARNING)
     logging.getLogger("websockets").setLevel(logging.WARNING)
     logging.getLogger("web3").setLevel(logging.WARNING)
+    logging.getLogger("asyncio").setLevel(logging.WARNING)
 
 # Recursively transforms template strings containing "${VALUE}". Example:
 # >>> template_transform("You are ${what}!", {"what": "${how} late", "how": "very"})

--- a/test/integration/framework/src/siftool/cosmos.py
+++ b/test/integration/framework/src/siftool/cosmos.py
@@ -29,6 +29,15 @@ def balance_add(*bal: Balance) -> Balance:
     return result
 
 
+def balance_mul(bal: Balance, multiplier: Union[int, float]) -> Balance:
+    result = {}
+    for denom, value in bal.items():
+        val = value * multiplier
+        if val != 0:
+            result[denom] = val
+    return result
+
+
 def balance_neg(bal: Balance) -> Balance:
     return {k: -v for k, v in bal.items()}
 

--- a/test/integration/framework/src/siftool/cosmos.py
+++ b/test/integration/framework/src/siftool/cosmos.py
@@ -19,10 +19,11 @@ def balance_normalize(bal: CompatBalance = None) -> Balance:
     return {k: v for k, v in bal.items() if v != 0}
 
 
-def balance_add(bal1: Balance, bal2: Balance) -> Balance:
+def balance_add(*bal: Balance) -> Balance:
     result = {}
-    for denom in set(bal1.keys()).union(set(bal2.keys())):
-        val = bal1.get(denom, 0) + bal2.get(denom, 0)
+    all_denoms = set(flatten_list([[*b.keys()] for b in bal]))
+    for denom in all_denoms:
+        val = sum(b.get(denom, 0) for b in bal)
         if val != 0:
             result[denom] = val
     return result
@@ -32,8 +33,8 @@ def balance_neg(bal: Balance) -> Balance:
     return {k: -v for k, v in bal.items()}
 
 
-def balance_sub(bal1: Balance, bal2: Balance) -> Balance:
-    return balance_add(bal1, balance_neg(bal2))
+def balance_sub(bal1: Balance, *bal2: Balance) -> Balance:
+    return balance_add(bal1, *[balance_neg(b) for b in bal2])
 
 
 def balance_zero(bal: Balance) -> bool:

--- a/test/integration/framework/src/siftool/eth.py
+++ b/test/integration/framework/src/siftool/eth.py
@@ -1,7 +1,9 @@
 import logging
 import time
 import web3
-from typing import NewType
+from hexbytes import HexBytes
+from web3.datastructures import AttributeDict
+from typing import NewType, Sequence
 
 from siftool.common import *
 
@@ -243,6 +245,15 @@ class EthereumTxWrapper:
         signed_tx = self.w3_conn.eth.account.sign_transaction(tx, private_key=private_key)
         txhash = self.w3_conn.eth.send_raw_transaction(signed_tx.rawTransaction)
         return txhash
+
+    def wait_for_all_transaction_receipts(self, tx_hashes: Sequence[HexBytes], sleep_time: int = 5,
+        timeout: Union[int, None] = None
+    ) -> Sequence[AttributeDict]:
+        result = []
+        for txhash in tx_hashes:
+            txrcpt = self.wait_for_transaction_receipt(txhash, sleep_time=sleep_time, timeout=timeout)
+            result.append(txrcpt)
+        return result
 
     def wait_for_transaction_receipt(self, txhash, sleep_time=5, timeout=None):
         return self.w3_conn.eth.wait_for_transaction_receipt(txhash, timeout=timeout, poll_latency=sleep_time)

--- a/test/integration/framework/src/siftool/eth.py
+++ b/test/integration/framework/src/siftool/eth.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import web3
+from typing import NewType
 
 from siftool.common import *
 
@@ -9,6 +10,7 @@ ETH = 10**18
 GWEI = 10**9
 NULL_ADDRESS = "0x0000000000000000000000000000000000000000"
 MIN_TX_GAS = 21000
+Address = NewType("Address", str)
 
 log = logging.getLogger(__name__)
 

--- a/test/integration/framework/src/siftool/eth.py
+++ b/test/integration/framework/src/siftool/eth.py
@@ -3,7 +3,7 @@ import time
 import web3
 import eth_typing
 from hexbytes import HexBytes
-from web3.datastructures import AttributeDict
+from web3.types import TxReceipt
 from typing import NewType, Sequence
 
 from siftool.common import *
@@ -249,14 +249,14 @@ class EthereumTxWrapper:
 
     def wait_for_all_transaction_receipts(self, tx_hashes: Sequence[HexBytes], sleep_time: int = 5,
         timeout: Union[int, None] = None
-    ) -> Sequence[AttributeDict]:
+    ) -> Sequence[TxReceipt]:
         result = []
         for txhash in tx_hashes:
             txrcpt = self.wait_for_transaction_receipt(txhash, sleep_time=sleep_time, timeout=timeout)
             result.append(txrcpt)
         return result
 
-    def wait_for_transaction_receipt(self, txhash, sleep_time=5, timeout=None):
+    def wait_for_transaction_receipt(self, txhash, sleep_time=5, timeout=None) -> TxReceipt:
         return self.w3_conn.eth.wait_for_transaction_receipt(txhash, timeout=timeout, poll_latency=sleep_time)
 
     def transact_sync(self, smart_contract_function, eth_addr, tx_opts=None, timeout=None):

--- a/test/integration/framework/src/siftool/eth.py
+++ b/test/integration/framework/src/siftool/eth.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import web3
+import eth_typing
 from hexbytes import HexBytes
 from web3.datastructures import AttributeDict
 from typing import NewType, Sequence
@@ -12,7 +13,7 @@ ETH = 10**18
 GWEI = 10**9
 NULL_ADDRESS = "0x0000000000000000000000000000000000000000"
 MIN_TX_GAS = 21000
-Address = NewType("Address", str)
+Address = eth_typing.AnyAddress
 
 log = logging.getLogger(__name__)
 

--- a/test/integration/framework/src/siftool/inflate_tokens.py
+++ b/test/integration/framework/src/siftool/inflate_tokens.py
@@ -271,10 +271,10 @@ class InflateTokens:
             self.transfer_from_eth_to_sifnode(eth_broker_account, sif_broker_account, tokens_to_transfer, total_token_amount, total_eth_amount_gwei)
         self.distribute_tokens_to_wallets(sif_broker_account, tokens_to_transfer, token_amount, target_sif_accounts, eth_amount_gwei)
 
-    def transfer_eth(self, from_eth_addr, amount_gewi, target_sif_accounts):
+    def transfer_eth(self, from_eth_addr, amount_gwei, target_sif_accounts):
         pending_txs = []
         for sif_acct in target_sif_accounts:
-            txrcpt = self.ctx.eth.tx_bridge_bank_lock_eth(from_eth_addr, sif_acct, amount_gewi * eth.GWEI)
+            txrcpt = self.ctx.eth.tx_bridge_bank_lock_eth(from_eth_addr, sif_acct, amount_gwei * eth.GWEI)
             pending_txs.append(txrcpt)
         self.wait_for_all(pending_txs)
 

--- a/test/integration/framework/src/siftool/sifchain.py
+++ b/test/integration/framework/src/siftool/sifchain.py
@@ -2,17 +2,27 @@ import base64
 import json
 import time
 import grpc
-from typing import Mapping, Any
-from siftool import command, cosmos
+import re
+import web3
+from typing import Mapping, Any, Tuple
+from siftool import command, cosmos, eth
 from siftool.common import *
 
-def sifchain_denom_hash(network_descriptor: int, token_contract_address: str) -> str:
+def sifchain_denom_hash(network_descriptor: int, token_contract_address: eth.Address) -> str:
     assert on_peggy2_branch
     assert token_contract_address.startswith("0x")
     assert type(network_descriptor) == int
     assert network_descriptor in range(1, 10000)
     denom = f"sifBridge{network_descriptor:04d}{token_contract_address.lower()}"
     return denom
+
+def sifchain_denom_hash_to_token_contract_address(token_hash: str) -> Tuple[int, eth.Address]:
+    m = re.match("^sifBridge(\\d{4})0x([0-9a-fA-F]{40})$", token_hash)
+    if not m:
+        raise Exception("Invalid sifchain denom '{}'".format(token_hash))
+    network_descriptor = int(m[1])
+    token_address = web3.Web3.toChecksumAddress(m[2])
+    return network_descriptor, token_address
 
 # Deprecated
 def balance_delta(balances1: cosmos.Balance, balances2: cosmos.Balance) -> cosmos.Balance:

--- a/test/integration/framework/src/siftool/test_utils.py
+++ b/test/integration/framework/src/siftool/test_utils.py
@@ -321,7 +321,7 @@ class EnvCtx:
         abi, _, _ = self.abi_provider.get_descriptor(self.generic_erc20_contract)
         return self.w3_conn.eth.contract(abi=abi, address=address)
 
-    def get_erc20_token_balance(self, token_addr, eth_addr) -> int:
+    def get_erc20_token_balance(self, token_addr: eth.Address, eth_addr: eth.Address) -> int:
         token_sc = self.get_generic_erc20_sc(token_addr)
         return token_sc.functions.balanceOf(eth_addr).call()
 
@@ -580,7 +580,9 @@ class EnvCtx:
             assert cosmos.balance_zero(cosmos.balance_sub(new_balances, fund_amounts))
         return sif_address
 
-    def send_from_sifchain_to_sifchain(self, from_sif_addr, to_sif_addr, amounts):
+    def send_from_sifchain_to_sifchain(self, from_sif_addr: cosmos.Address, to_sif_addr: cosmos.Address,
+        amounts: cosmos.Balance
+    ):
         amounts = cosmos.balance_normalize(amounts)
         amounts_string = cosmos.balance_format(amounts)
         args = ["tx", "bank", "send", from_sif_addr, to_sif_addr, amounts_string] + \

--- a/test/integration/framework/src/siftool/test_utils.py
+++ b/test/integration/framework/src/siftool/test_utils.py
@@ -608,8 +608,8 @@ class EnvCtx:
     # - if neither min_changes nor expected_balance are given: when anything changes.
     # You cannot use min_changes and expected_balance at the same time.
     def wait_for_sif_balance_change(self, sif_addr: cosmos.Address, old_balance: cosmos.Balance,
-        min_changes: cosmos.CompatBalance = None, expected_balance: cosmos.CompatBalance = None, polling_time=1,
-        timeout=90, change_timeout=None
+        min_changes: cosmos.CompatBalance = None, expected_balance: cosmos.CompatBalance = None, polling_time: int = 1,
+        timeout: int = 90, change_timeout: int = None
     ) -> cosmos.Balance:
         assert (min_changes is None) or (expected_balance is None), "Cannot use both min_changes and expected_balance"
         min_changes = None if min_changes is None else cosmos.balance_normalize(min_changes)

--- a/test/integration/setup-linux-environment-user.sh
+++ b/test/integration/setup-linux-environment-user.sh
@@ -27,4 +27,5 @@ echo '. ~/.bash_profile' >> ~/.bashrc
 . ~/.bash_profile
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
 
-python3 -m pip install -U pytest web3
+python3 -m pip install -U pytest web3 grpcio-tools
+

--- a/test/integration/src/peggy2/siftool_path.py
+++ b/test/integration/src/peggy2/siftool_path.py
@@ -7,10 +7,5 @@ base_dir = os.path.join(project_root, "test", "integration", "framework")
 src_dir = os.path.join(base_dir, "src")
 build_generated_dir = os.path.join(base_dir, "build", "generated")
 paths = [src_dir, build_generated_dir]
-enabled = False
-paths_to_add = []
-for p in paths:
-    enabled = any([os.path.realpath(p) == os.path.realpath(s) for s in sys.path])
-    if not enabled:
-        paths_to_add.append(p)
+paths_to_add = [p for p in paths if not any(os.path.realpath(p) == os.path.realpath(s) for s in sys.path)]
 sys.path.extend(paths_to_add)

--- a/test/load/load_testing.py
+++ b/test/load/load_testing.py
@@ -1,6 +1,9 @@
 import random
+from hexbytes import HexBytes
 from typing import Sequence, Any
+from web3.datastructures import AttributeDict
 
+from siftool import eth, test_utils
 
 # Fees for sifchain -> sifchain transactions, paid by the sender.
 sif_tx_fee_in_rowan = 1 * 10**17
@@ -18,6 +21,20 @@ sif_tx_burn_fee_in_ceth = 1
 sif_tx_burn_fee_buffer_in_rowan = 5 * sif_tx_fee_in_rowan
 
 rowan = "rowan"
+
+# Fee for transfering ERC20 tokens from an ethereum account to sif account (approve + lock). This is the maximum cost
+# for a single transfer (regardless of amount) that the sender needs to have in his account in order for transaction to
+# be processed. This value was determined experimentally with hardhat. Typical effective fee is 210542 GWEI per
+# transaction, but for some reason the logic requires sender to have more funds in his account.
+max_eth_transfer_fee = 10000000 * eth.GWEI
+
+
+def wait_for_all_tx_receipts(ctx: test_utils.EnvCtx, tx_hashes: Sequence[HexBytes]) -> Sequence[AttributeDict]:
+    result = []
+    for txhash in tx_hashes:
+        txrcpt = ctx.eth.wait_for_transaction_receipt(txhash)
+        result.append(txrcpt)
+    return result
 
 
 def choose_from(distr: Sequence[Any], rnd: random.Random = None) -> int:

--- a/test/load/load_testing.py
+++ b/test/load/load_testing.py
@@ -54,9 +54,7 @@ def send_from_sifchain_to_sifchain(ctx: test_utils.EnvCtx, from_addr: cosmos.Add
 def send_erc20_from_sifchain_to_ethereum(ctx: test_utils.EnvCtx, from_addr: cosmos.Address, to_addr: eth.Address,
     amount: int, denom: str
 ):
-    assert on_peggy2_branch
-    ethereum_network_descriptor, token_address = sifchain.sifchain_denom_hash_to_token_contract_address(denom)
-    assert ethereum_network_descriptor == ctx.eth.ethereum_network_descriptor  # Note: peggy2 only
+    token_address = get_erc20_token_address(ctx, denom)
     sif_balance_before = ctx.get_sifchain_balance(from_addr)
     eth_balance_before = ctx.get_erc20_token_balance(token_address, to_addr)
     ctx.sifnode_client.send_from_sifchain_to_ethereum(from_addr, to_addr, amount, denom)
@@ -66,6 +64,13 @@ def send_erc20_from_sifchain_to_ethereum(ctx: test_utils.EnvCtx, from_addr: cosm
     sif_burn_fees = get_sif_burn_fees(ctx)
     assert cosmos.balance_equal(sif_balance_after, cosmos.balance_sub(sif_balance_before, {denom: amount},  sif_burn_fees))
     assert eth_balance_after == eth_balance_before + amount
+
+
+def get_erc20_token_address(ctx: test_utils.EnvCtx, sif_denom_hash: str) -> eth.Address:
+    assert on_peggy2_branch
+    ethereum_network_descriptor, token_address = sifchain.sifchain_denom_hash_to_token_contract_address(sif_denom_hash)
+    assert ethereum_network_descriptor == ctx.eth.ethereum_network_descriptor  # Note: peggy2 only
+    return token_address
 
 
 def choose_from(distr: Sequence[Any], rnd: random.Random = None) -> int:

--- a/test/load/load_testing.py
+++ b/test/load/load_testing.py
@@ -1,7 +1,5 @@
 import random
-from hexbytes import HexBytes
 from typing import Sequence, Any
-from web3.datastructures import AttributeDict
 
 from siftool import eth, test_utils
 
@@ -27,14 +25,6 @@ rowan = "rowan"
 # be processed. This value was determined experimentally with hardhat. Typical effective fee is 210542 GWEI per
 # transaction, but for some reason the logic requires sender to have more funds in his account.
 max_eth_transfer_fee = 10000000 * eth.GWEI
-
-
-def wait_for_all_tx_receipts(ctx: test_utils.EnvCtx, tx_hashes: Sequence[HexBytes]) -> Sequence[AttributeDict]:
-    result = []
-    for txhash in tx_hashes:
-        txrcpt = ctx.eth.wait_for_transaction_receipt(txhash)
-        result.append(txrcpt)
-    return result
 
 
 def choose_from(distr: Sequence[Any], rnd: random.Random = None) -> int:

--- a/test/load/siftool_path.py
+++ b/test/load/siftool_path.py
@@ -7,10 +7,5 @@ base_dir = os.path.join(project_root, "test", "integration", "framework")
 src_dir = os.path.join(base_dir, "src")
 build_generated_dir = os.path.join(base_dir, "build", "generated")
 paths = [src_dir, build_generated_dir]
-enabled = False
-paths_to_add = []
-for p in paths:
-    enabled = any([os.path.realpath(p) == os.path.realpath(s) for s in sys.path])
-    if not enabled:
-        paths_to_add.append(p)
+paths_to_add = [p for p in paths if not any(os.path.realpath(p) == os.path.realpath(s) for s in sys.path)]
 sys.path.extend(paths_to_add)

--- a/test/load/test_many_denoms.py
+++ b/test/load/test_many_denoms.py
@@ -1,0 +1,124 @@
+import logging.handlers
+import time
+import logging
+from typing import Callable, Tuple, Iterable, List
+from hexbytes import HexBytes
+
+import siftool_path
+
+from siftool import cosmos, eth, sifchain, test_utils
+from siftool.common import *
+from load_testing import *
+
+
+def batch_deploy_erc20_tokens(ctx: test_utils.EnvCtx, count: int, deployer_addr: eth.Address,
+    token_data_provider: Callable[[int], Tuple[str, str, int, str]]
+) -> List[eth.Address]:
+    abi, bytecode, _ = ctx.abi_provider.get_descriptor(ctx.generic_erc20_contract)
+    token_sc = ctx.w3_conn.eth.contract(abi=abi, bytecode=bytecode)
+
+    txhashes = []
+    start_time = time.time()
+
+    for i in range(count):
+        name, symbol, decimals, cosmos_denom = token_data_provider(i)
+        constructor_args = [name, symbol, decimals, cosmos_denom]
+        txhash = ctx.eth.transact(token_sc.constructor, deployer_addr)(*constructor_args)
+        txhashes.append(txhash)
+        elapsed_time = time.time() - start_time
+        logging.debug("Created {} tokens, speed {:.2f}/s".format(i, 0 if elapsed_time == 0 else i / elapsed_time))
+    txrcpts = wait_for_all_tx_receipts(ctx, txhashes)
+    contract_addresses = [txrcpt.contractAddress for txrcpt in txrcpts]
+    return contract_addresses
+
+
+def batch_mint_erc20_tokens(ctx: test_utils.EnvCtx, minter_account: eth.Address,
+    minted_tokens_recipient: eth.Address, amount: int, contracts: Iterable[eth.Address]
+):
+    txhashes = []
+    abi, bytecode, _ = ctx.abi_provider.get_descriptor(ctx.generic_erc20_contract)
+    for contract_address in contracts:
+        token_sc = ctx.w3_conn.eth.contract(abi=abi, address=contract_address)
+        txhash = ctx.eth.transact(token_sc.functions.mint, minter_account)(minted_tokens_recipient, amount)
+        txhashes.append(txhash)
+    wait_for_all_tx_receipts(ctx, txhashes)
+
+
+def batch_approve_and_lock_erc20_tokens(ctx: test_utils.EnvCtx, from_eth_acct: eth.Address,
+    to_sif_acct: cosmos.Address, token_addrs: Iterable[eth.Address], amount: int
+):
+    abi, bytecode, _ = ctx.abi_provider.get_descriptor(ctx.generic_erc20_contract)
+    bridge_bank_sc = ctx.get_bridge_bank_sc()
+    txhashes = []
+    for token_addr in token_addrs:
+        token_sc = ctx.w3_conn.eth.contract(abi=abi, address=token_addr)
+        txhash = ctx.eth.transact(token_sc.functions.approve, from_eth_acct)(bridge_bank_sc.address, amount)
+        txhashes.append(txhash)
+    wait_for_all_tx_receipts(ctx, txhashes)
+
+    to_sif_acct_encoded = test_utils.sif_addr_to_evm_arg(to_sif_acct)
+    txrcpts = []
+    for token_addr in token_addrs:
+        tx_opts = {"value": 0}
+        txrcpt = ctx.eth.transact(bridge_bank_sc.functions.lock, from_eth_acct, tx_opts=tx_opts)(to_sif_acct_encoded, token_addr, amount)
+        txrcpts.append(txrcpt)
+    wait_for_all_tx_receipts(ctx, txrcpts)
+
+
+def test(ctx):
+    _test(ctx, 10000)
+
+
+def _test(ctx, number_of_erc20_tokens):
+    token_name_base = random_string(4)
+    owner = ctx.operator
+
+    eth_sender = ctx.create_and_fund_eth_account(fund_amount=max_eth_transfer_fee * number_of_erc20_tokens)
+    sif_recipient = ctx.create_sifchain_addr()
+
+    def token_data_provider(i: int) -> Tuple[str, str, int, str]:
+        token_name = "{}{}".format(token_name_base, i)
+        token_symbol = "eth-symbol-{}".format(i)
+        token_decimals = 6
+        cosmos_denom = "cosmos-symbol-{}".format(i)
+        return token_name, token_symbol, token_decimals, cosmos_denom
+
+    start_time = time.time()
+    time_before = start_time
+    contract_addresses = batch_deploy_erc20_tokens(ctx, number_of_erc20_tokens, ctx.operator, token_data_provider)
+    deploy_time = time.time() - time_before
+
+    logging.debug("batch_deploy_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(deploy_time,
+        number_of_erc20_tokens / deploy_time if deploy_time > 0 else 0))
+
+    sif_denoms = [sifchain.sifchain_denom_hash(ctx.eth.ethereum_network_descriptor, addr) for addr in contract_addresses]
+
+    amount = 123456
+
+    start_time = time.time()
+    batch_mint_erc20_tokens(ctx, owner, eth_sender, amount, contract_addresses)
+    mint_time = time.time() - time_before
+
+    logging.debug("batch_mint_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(mint_time,
+        number_of_erc20_tokens / mint_time if mint_time > 0 else 0))
+
+    eth_balance_before = ctx.eth.get_eth_balance(eth_sender)
+    sif_balance_before = ctx.get_sifchain_balance(sif_recipient)
+
+    start_time = time.time()
+    batch_approve_and_lock_erc20_tokens(ctx, eth_sender, sif_recipient, contract_addresses, amount)
+    approva_and_lock_time = time.time() - time_before
+    logging.debug("batch_approve_and_lock_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(approva_and_lock_time,
+        number_of_erc20_tokens / approva_and_lock_time if approva_and_lock_time > 0 else 0))
+
+    expected_balance = {denom: amount for denom in sif_denoms}
+    start_time = time.time()
+    sif_balance_after = ctx.wait_for_sif_balance_change(sif_recipient, sif_balance_before, expected_balance=expected_balance)
+    balance_change_time = time.time() - time_before
+
+    logging.debug("wait_for_sif_balance_change(): {:.2f} s, {:.2f} items/s".format(balance_change_time,
+        number_of_erc20_tokens / balance_change_time if balance_change_time > 0 else 0))
+
+    total_time = time.time() - start_time
+
+    eth_balance_after = ctx.eth.get_eth_balance(eth_sender)

--- a/test/load/test_many_denoms.py
+++ b/test/load/test_many_denoms.py
@@ -1,10 +1,12 @@
 import sys
 import time
 import logging
+import argparse
 from typing import Callable, Tuple, Iterable, List
 
 import siftool_path
-from siftool import cosmos, eth, sifchain, test_utils
+from siftool import cosmos, eth, sifchain, test_utils, command
+from siftool.cosmos import balance_add, balance_sub, balance_equal, balance_mul
 from siftool.common import *
 from load_testing import *
 
@@ -45,34 +47,80 @@ def batch_approve_and_lock_erc20_tokens(ctx: test_utils.EnvCtx, from_eth_acct: e
 ):
     abi, bytecode, _ = ctx.abi_provider.get_descriptor(ctx.generic_erc20_contract)
     bridge_bank_sc = ctx.get_bridge_bank_sc()
+    to_sif_acct_encoded = test_utils.sif_addr_to_evm_arg(to_sif_acct)
     txhashes = []
     for token_addr in token_addrs:
         token_sc = ctx.w3_conn.eth.contract(abi=abi, address=token_addr)
         txhash = ctx.eth.transact(token_sc.functions.approve, from_eth_acct)(bridge_bank_sc.address, amount)
         txhashes.append(txhash)
     ctx.eth.wait_for_all_transaction_receipts(txhashes)
-
-    to_sif_acct_encoded = test_utils.sif_addr_to_evm_arg(to_sif_acct)
-    txrcpts = []
+    txhashes = []
     for token_addr in token_addrs:
         tx_opts = {"value": 0}
-        txrcpt = ctx.eth.transact(bridge_bank_sc.functions.lock, from_eth_acct, tx_opts=tx_opts)(to_sif_acct_encoded, token_addr, amount)
-        txrcpts.append(txrcpt)
-    ctx.eth.wait_for_all_transaction_receipts(txrcpts)
+        txhash = ctx.eth.transact(bridge_bank_sc.functions.lock, from_eth_acct, tx_opts=tx_opts)(to_sif_acct_encoded, token_addr, amount)
+        txhashes.append(txhash)
+    ctx.eth.wait_for_all_transaction_receipts(txhashes)
+
+
+def timed_tx_send_loop(ctx: test_utils.EnvCtx, src_sif_address: cosmos.Address, dst_sif_address: cosmos.Address,
+    tx_amount: cosmos.Balance, loop_count: int
+) -> float:
+    sif_tx_fee = get_sif_tx_fees(ctx)
+    send_from_sifchain_to_sifchain(ctx, ctx.rowan_source, src_sif_address, balance_mul(sif_tx_fee, loop_count))
+    src_initial_balance = ctx.get_sifchain_balance(src_sif_address)
+    dst_initial_balance = ctx.get_sifchain_balance(dst_sif_address)
+    time_before = time.time()
+    for i in range(loop_count):
+        send_from_sifchain_to_sifchain(ctx, src_sif_address, dst_sif_address, tx_amount)
+        src_expected_balance = balance_sub(src_initial_balance, balance_mul(balance_add(tx_amount, sif_tx_fee), i + 1))
+        dst_expected_balance = balance_add(dst_initial_balance, balance_mul(tx_amount, i + 1))
+        src_actual_balance = ctx.get_sifchain_balance(src_sif_address)
+        dst_actual_balance = ctx.get_sifchain_balance(dst_sif_address)
+        assert balance_equal(src_actual_balance, src_expected_balance)
+        assert balance_equal(dst_actual_balance, dst_expected_balance)
+    return time.time() - time_before
+
+
+def timed_tx_burn_loop(ctx: test_utils.EnvCtx, src_sif_address: cosmos.Address, dst_eth_address: eth.Address,
+    denom: str, amount: int, loop_count: int
+) -> float:
+    sif_burn_fee = get_sif_burn_fees(ctx)
+    send_from_sifchain_to_sifchain(ctx, ctx.rowan_source, src_sif_address, balance_mul(sif_burn_fee, loop_count))
+    tx_denom_token_address = get_erc20_token_address(ctx, denom)
+    src_initial_balance = ctx.get_sifchain_balance(src_sif_address)
+    dst_initial_balance = ctx.get_erc20_token_balance(tx_denom_token_address, dst_eth_address)
+    time_before = time.time()
+    for i in range(loop_count):
+        send_erc20_from_sifchain_to_ethereum(ctx, src_sif_address, dst_eth_address, amount, denom)
+        src_expected_balance = balance_sub(src_initial_balance, balance_mul(balance_add({denom: amount}, sif_burn_fee), i + 1))
+        dst_expected_balance = dst_initial_balance + amount * (i + 1)
+        src_actual_balance = ctx.get_sifchain_balance(src_sif_address)
+        dst_actual_balance = ctx.get_erc20_token_balance(tx_denom_token_address, dst_eth_address)
+        assert balance_equal(src_actual_balance, src_expected_balance)
+        assert dst_actual_balance == dst_expected_balance
+    return time.time() - time_before
+
+
+def report(report_lines: List[str], message: str):
+    log.info(message)
+    report_lines.append(message)
 
 
 def test(ctx: test_utils.EnvCtx):
     _test(ctx, 2)
 
 
-def _test(ctx: test_utils.EnvCtx, number_of_erc20_tokens: int):
+def _test(ctx: test_utils.EnvCtx, number_of_erc20_tokens: int, report_lines: Union[List[str], None] = None):
+    report_lines = [] if report_lines is None else report_lines
     assert number_of_erc20_tokens > 1
 
     token_name_base = random_string(4)
     owner = ctx.operator
+    test_start_time = time.time()
 
     eth_sender = ctx.create_and_fund_eth_account(fund_amount=max_eth_transfer_fee * number_of_erc20_tokens)
-    sif_recipient = ctx.create_sifchain_addr()
+    fat_sif_wallet = ctx.create_sifchain_addr()
+    slim_sif_wallet = ctx.create_sifchain_addr()
 
     def token_data_provider(i: int) -> Tuple[str, str, int]:
         token_name = "{}{}".format(token_name_base, i)
@@ -80,78 +128,103 @@ def _test(ctx: test_utils.EnvCtx, number_of_erc20_tokens: int):
         token_decimals = 6
         return token_name, token_symbol, token_decimals
 
-    start_time = time.time()
-    time_before = start_time
+    report(report_lines, "Number of tokens: {}".format(number_of_erc20_tokens))
+
+    setup_start_time = time.time()
+    time_before = time.time()
     contract_addresses = batch_deploy_erc20_tokens(ctx, number_of_erc20_tokens, ctx.operator, token_data_provider)
     deploy_time = time.time() - time_before
 
-    log.debug("batch_deploy_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(deploy_time,
+    report(report_lines, "batch_deploy_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(deploy_time,
         number_of_erc20_tokens / deploy_time if deploy_time > 0 else 0))
 
     sif_denoms = [sifchain.sifchain_denom_hash(ctx.eth.ethereum_network_descriptor, addr) for addr in contract_addresses]
 
-    amount = 123456
+    amount = 123456  # Must be > test_loop_count
 
     time_before = time.time()
     batch_mint_erc20_tokens(ctx, owner, eth_sender, amount, contract_addresses)
     mint_time = time.time() - time_before
 
-    log.debug("batch_mint_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(mint_time,
+    report(report_lines, "batch_mint_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(mint_time,
         number_of_erc20_tokens / mint_time if mint_time > 0 else 0))
 
     eth_balance_before = ctx.eth.get_eth_balance(eth_sender)
-    sif_balance_before = ctx.get_sifchain_balance(sif_recipient)
+    sif_balance_before = ctx.get_sifchain_balance(fat_sif_wallet)
 
     time_before = time.time()
-    batch_approve_and_lock_erc20_tokens(ctx, eth_sender, sif_recipient, contract_addresses, amount)
+    batch_approve_and_lock_erc20_tokens(ctx, eth_sender, fat_sif_wallet, contract_addresses, amount)
     approve_and_lock_time = time.time() - time_before
-    log.debug("batch_approve_and_lock_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(approve_and_lock_time,
+    report(report_lines, "batch_approve_and_lock_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(approve_and_lock_time,
         number_of_erc20_tokens / approve_and_lock_time if approve_and_lock_time > 0 else 0))
 
-    expected_balance = {denom: amount for denom in sif_denoms}
+    fat_balance = {denom: amount for denom in sif_denoms}
     time_before = time.time()
-    sif_balance_after = ctx.wait_for_sif_balance_change(sif_recipient, sif_balance_before, expected_balance=expected_balance)
+    ctx.wait_for_sif_balance_change(fat_sif_wallet, sif_balance_before, expected_balance=fat_balance)
     balance_change_time = time.time() - time_before
+    assert balance_equal(ctx.get_sifchain_balance(fat_sif_wallet), fat_balance)
 
-    log.debug("wait_for_sif_balance_change(): {:.2f} s, {:.2f} items/s".format(balance_change_time,
+    report(report_lines, "wait_for_sif_balance_change(): {:.2f} s, {:.2f} items/s".format(balance_change_time,
         number_of_erc20_tokens / balance_change_time if balance_change_time > 0 else 0))
 
-    total_time = time.time() - start_time
+    setup_time = time.time() - setup_start_time
 
     eth_balance_after = ctx.eth.get_eth_balance(eth_sender)
+    report(report_lines, "Cost of approve+lock: {:.2f} gwei".format(
+        (eth_balance_before - eth_balance_after) / number_of_erc20_tokens / eth.GWEI))
 
-    log.debug("Total: {:.2f} s, {:.2f} items/s".format(total_time,
-        number_of_erc20_tokens / total_time if total_time > 0 else 0))
+    report(report_lines, "Total for setup (mint+approve+lock): {:.2f} s, {:.2f} items/s".format(setup_time,
+        number_of_erc20_tokens / setup_time if setup_time > 0 else 0))
 
-    transfer = {rowan: sif_tx_fee_in_rowan}
-    ctx.send_from_sifchain_to_sifchain(ctx.rowan_source, sif_recipient, transfer)
+    # Populate slim wallet with only one denom. Slim wallet is used to compare relative performance of a sif account
+    # with just one denom to performance of a sif account with many denoms, all other things being equal.
+    token0 = contract_addresses[0]
+    denom0 = sif_denoms[0]
+    expected_slim_balance = {denom0: amount}
+    slim_balance_before = ctx.get_sifchain_balance(slim_sif_wallet)
+    batch_mint_erc20_tokens(ctx, owner, eth_sender, amount, [token0])
+    batch_approve_and_lock_erc20_tokens(ctx, eth_sender, slim_sif_wallet, [token0], amount)
+    ctx.wait_for_sif_balance_change(slim_sif_wallet, sif_balance_before, expected_balance=expected_slim_balance)
+    assert cosmos.balance_equal(ctx.get_sifchain_balance(slim_sif_wallet), expected_slim_balance)
 
-    expected_balance_1 = cosmos.balance_add(expected_balance, transfer)
-    ctx.wait_for_sif_balance_change(sif_recipient, sif_balance_after, expected_balance=expected_balance_1)
+    # We do few transfers and burns to get the average time per transaction for fat wallet.
+    # We assert that the fees are equal to the fee of a single transaction as given by get_sif_tx_fees() and
+    # get_sif_burn_fees().
 
-    tx_fee = get_sif_tx_fees(ctx)
-    tmp_sif_accounts = [ctx.create_sifchain_addr(fund_amounts=tx_fee) for _ in range(1)]
+    test_loop_count = 10
 
-    denom1, denom2 = sif_denoms[0:2]
-    transfer = {denom1: amount, denom2: 1}
-    expected_balance_2 = cosmos.balance_sub(expected_balance_1, transfer, tx_fee)
-    prev_balance = ctx.get_sifchain_balance(tmp_sif_accounts[0])
-    ctx.send_from_sifchain_to_sifchain(sif_recipient, tmp_sif_accounts[0], transfer)
-    ctx.wait_for_sif_balance_change(tmp_sif_accounts[0], prev_balance, transfer)
-    assert cosmos.balance_equal(ctx.get_sifchain_balance(sif_recipient), expected_balance_2)
-    assert cosmos.balance_equal(ctx.get_sifchain_balance(tmp_sif_accounts[0]), cosmos.balance_add(tx_fee, transfer))
+    tmp_sif_account = ctx.create_sifchain_addr()
+    tmp_eth_account = ctx.create_and_fund_eth_account()
 
-    sif_burn_fees = get_sif_burn_fees(ctx)
-    send_from_sifchain_to_sifchain(ctx, ctx.rowan_source, sif_recipient, sif_burn_fees)
+    sif_send_time_fat = timed_tx_send_loop(ctx, fat_sif_wallet, tmp_sif_account, {denom0: 1}, test_loop_count)
+    report(report_lines, "Average tx_send time for fat_sif_wallet: {:.2f} s".format(sif_send_time_fat / test_loop_count))
 
-    test_eth_accts = [ctx.create_and_fund_eth_account() for _ in range(1)]
-    send_erc20_from_sifchain_to_ethereum(ctx, sif_recipient, test_eth_accts[0], amount - 1, denom2)
+    sif_burn_time_fat = timed_tx_burn_loop(ctx, fat_sif_wallet, tmp_eth_account, denom0, 1, test_loop_count)
+    report(report_lines, "Average tx_burn time for fat_sif_wallet: {:.2f} s".format(sif_burn_time_fat / test_loop_count))
+
+    sif_send_time_slim = timed_tx_send_loop(ctx, slim_sif_wallet, tmp_sif_account, {denom0: 1}, test_loop_count)
+    report(report_lines, "Average tx_send time for slim_sif_wallet: {:.2f} s".format(sif_send_time_slim / test_loop_count))
+
+    sif_burn_time_slim = timed_tx_burn_loop(ctx, slim_sif_wallet, tmp_eth_account, denom0, 1, test_loop_count)
+    report(report_lines, "Average tx_burn time for slim_sif_wallet: {:.2f} s".format(sif_burn_time_slim / test_loop_count))
+
+    report(report_lines, "Relative fat/slim speed for tx_send: {:.2f}".format(sif_send_time_fat / sif_send_time_slim))
+    report(report_lines, "Relative fat/slim speed for tx_burn: {:.2f}".format(sif_burn_time_fat / sif_burn_time_slim))
+
+    test_total_time = time.time() - test_start_time
+    report(report_lines, "Total test time: {:.2f} s".format(test_total_time))
 
 
 # Enable running directly, i.e. without pytest
 if __name__ == "__main__":
     basic_logging_setup()
     ctx = test_utils.get_env_ctx()
-    number_of_erc20_tokens = int(sys.argv[1]) if len(sys.argv) == 2 else 2
-    _test(ctx, number_of_erc20_tokens)
-    log.info("Success")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", type=int, default=2)
+    parser.add_argument("--report")
+    args = parser.parse_args(sys.argv[1:])
+    report_lines = []
+    _test(ctx, args.count, report_lines=report_lines)
+    if args.report:
+        command.Command().write_text_file(args.report, joinlines(report_lines))
+    log.info("Finished successfully")

--- a/test/load/test_many_denoms.py
+++ b/test/load/test_many_denoms.py
@@ -2,7 +2,6 @@ import logging.handlers
 import time
 import logging
 from typing import Callable, Tuple, Iterable, List
-from hexbytes import HexBytes
 
 import siftool_path
 
@@ -11,23 +10,21 @@ from siftool.common import *
 from load_testing import *
 
 
+log = logging.getLogger(__name__)
+
+
 def batch_deploy_erc20_tokens(ctx: test_utils.EnvCtx, count: int, deployer_addr: eth.Address,
-    token_data_provider: Callable[[int], Tuple[str, str, int, str]]
+    token_data_provider: Callable[[int], Tuple[str, str, int]]
 ) -> List[eth.Address]:
     abi, bytecode, _ = ctx.abi_provider.get_descriptor(ctx.generic_erc20_contract)
     token_sc = ctx.w3_conn.eth.contract(abi=abi, bytecode=bytecode)
-
     txhashes = []
-    start_time = time.time()
-
     for i in range(count):
-        name, symbol, decimals, cosmos_denom = token_data_provider(i)
-        constructor_args = [name, symbol, decimals, cosmos_denom]
+        name, symbol, decimals = token_data_provider(i)
+        constructor_args = [name, symbol, decimals, "cosmos_denom"]  # Dummy value for cosmos_denom, actual denom will be sifBridgeDDDD0xXXX...X
         txhash = ctx.eth.transact(token_sc.constructor, deployer_addr)(*constructor_args)
         txhashes.append(txhash)
-        elapsed_time = time.time() - start_time
-        logging.debug("Created {} tokens, speed {:.2f}/s".format(i, 0 if elapsed_time == 0 else i / elapsed_time))
-    txrcpts = wait_for_all_tx_receipts(ctx, txhashes)
+    txrcpts = ctx.eth.wait_for_all_transaction_receipts(txhashes)
     contract_addresses = [txrcpt.contractAddress for txrcpt in txrcpts]
     return contract_addresses
 
@@ -41,7 +38,7 @@ def batch_mint_erc20_tokens(ctx: test_utils.EnvCtx, minter_account: eth.Address,
         token_sc = ctx.w3_conn.eth.contract(abi=abi, address=contract_address)
         txhash = ctx.eth.transact(token_sc.functions.mint, minter_account)(minted_tokens_recipient, amount)
         txhashes.append(txhash)
-    wait_for_all_tx_receipts(ctx, txhashes)
+    ctx.eth.wait_for_all_transaction_receipts(txhashes)
 
 
 def batch_approve_and_lock_erc20_tokens(ctx: test_utils.EnvCtx, from_eth_acct: eth.Address,
@@ -54,7 +51,7 @@ def batch_approve_and_lock_erc20_tokens(ctx: test_utils.EnvCtx, from_eth_acct: e
         token_sc = ctx.w3_conn.eth.contract(abi=abi, address=token_addr)
         txhash = ctx.eth.transact(token_sc.functions.approve, from_eth_acct)(bridge_bank_sc.address, amount)
         txhashes.append(txhash)
-    wait_for_all_tx_receipts(ctx, txhashes)
+    ctx.eth.wait_for_all_transaction_receipts(txhashes)
 
     to_sif_acct_encoded = test_utils.sif_addr_to_evm_arg(to_sif_acct)
     txrcpts = []
@@ -62,11 +59,11 @@ def batch_approve_and_lock_erc20_tokens(ctx: test_utils.EnvCtx, from_eth_acct: e
         tx_opts = {"value": 0}
         txrcpt = ctx.eth.transact(bridge_bank_sc.functions.lock, from_eth_acct, tx_opts=tx_opts)(to_sif_acct_encoded, token_addr, amount)
         txrcpts.append(txrcpt)
-    wait_for_all_tx_receipts(ctx, txrcpts)
+    ctx.eth.wait_for_all_transaction_receipts(txrcpts)
 
 
 def test(ctx):
-    _test(ctx, 10000)
+    _test(ctx, 5000)
 
 
 def _test(ctx, number_of_erc20_tokens):
@@ -76,49 +73,51 @@ def _test(ctx, number_of_erc20_tokens):
     eth_sender = ctx.create_and_fund_eth_account(fund_amount=max_eth_transfer_fee * number_of_erc20_tokens)
     sif_recipient = ctx.create_sifchain_addr()
 
-    def token_data_provider(i: int) -> Tuple[str, str, int, str]:
+    def token_data_provider(i: int) -> Tuple[str, str, int]:
         token_name = "{}{}".format(token_name_base, i)
         token_symbol = "eth-symbol-{}".format(i)
         token_decimals = 6
-        cosmos_denom = "cosmos-symbol-{}".format(i)
-        return token_name, token_symbol, token_decimals, cosmos_denom
+        return token_name, token_symbol, token_decimals
 
     start_time = time.time()
     time_before = start_time
     contract_addresses = batch_deploy_erc20_tokens(ctx, number_of_erc20_tokens, ctx.operator, token_data_provider)
     deploy_time = time.time() - time_before
 
-    logging.debug("batch_deploy_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(deploy_time,
+    log.debug("batch_deploy_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(deploy_time,
         number_of_erc20_tokens / deploy_time if deploy_time > 0 else 0))
 
     sif_denoms = [sifchain.sifchain_denom_hash(ctx.eth.ethereum_network_descriptor, addr) for addr in contract_addresses]
 
     amount = 123456
 
-    start_time = time.time()
+    time_before = time.time()
     batch_mint_erc20_tokens(ctx, owner, eth_sender, amount, contract_addresses)
     mint_time = time.time() - time_before
 
-    logging.debug("batch_mint_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(mint_time,
+    log.debug("batch_mint_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(mint_time,
         number_of_erc20_tokens / mint_time if mint_time > 0 else 0))
 
     eth_balance_before = ctx.eth.get_eth_balance(eth_sender)
     sif_balance_before = ctx.get_sifchain_balance(sif_recipient)
 
-    start_time = time.time()
+    time_before = time.time()
     batch_approve_and_lock_erc20_tokens(ctx, eth_sender, sif_recipient, contract_addresses, amount)
-    approva_and_lock_time = time.time() - time_before
-    logging.debug("batch_approve_and_lock_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(approva_and_lock_time,
-        number_of_erc20_tokens / approva_and_lock_time if approva_and_lock_time > 0 else 0))
+    approve_and_lock_time = time.time() - time_before
+    log.debug("batch_approve_and_lock_erc20_tokens(): {:.2f} s, {:.2f} items/s".format(approve_and_lock_time,
+        number_of_erc20_tokens / approve_and_lock_time if approve_and_lock_time > 0 else 0))
 
     expected_balance = {denom: amount for denom in sif_denoms}
-    start_time = time.time()
+    time_before = time.time()
     sif_balance_after = ctx.wait_for_sif_balance_change(sif_recipient, sif_balance_before, expected_balance=expected_balance)
     balance_change_time = time.time() - time_before
 
-    logging.debug("wait_for_sif_balance_change(): {:.2f} s, {:.2f} items/s".format(balance_change_time,
+    log.debug("wait_for_sif_balance_change(): {:.2f} s, {:.2f} items/s".format(balance_change_time,
         number_of_erc20_tokens / balance_change_time if balance_change_time > 0 else 0))
 
     total_time = time.time() - start_time
 
     eth_balance_after = ctx.eth.get_eth_balance(eth_sender)
+
+    log.debug("Total: {:.2f} s, {:.2f} items/s".format(total_time,
+        number_of_erc20_tokens / total_time if total_time > 0 else 0))

--- a/test/localnet/utils/tests/__snapshots__/getChains.test.mjs.snap
+++ b/test/localnet/utils/tests/__snapshots__/getChains.test.mjs.snap
@@ -124,7 +124,6 @@ Object {
   },
   "sentinel": Object {
     "binary": "sentinelhub",
-    "binaryUrl": "https://github.com/sentinel-official/sentinel/archive/refs/tags/v0.1.4.zip",
     "chainId": "sentinelhub-2",
     "denom": "udvpn",
     "devnet-1": Object {
@@ -139,6 +138,8 @@ Object {
     "pprofPort": 13004,
     "prefix": "sent",
     "rpcPort": 11004,
+    "sourceRelativePath": "sentinel-0.1.4",
+    "sourceUrl": "https://github.com/sentinel-official/sentinel/archive/refs/tags/v0.1.4.zip",
     "testnet-1": Object {
       "channelId": 39,
       "counterpartyChannelId": 2,


### PR DESCRIPTION
This test creates up to 5000 ERC20 tokens and transfers them to a single sif account.
It checks that the wallet is usable (it can transfer funds to/from another sif wallet and do ethbridge burn).
It asserts that the fees are constant.
It measures the relative performance of a wallet with many denoms vs. wallet with one denom.

This PR is part of #2520.