### PR TITLE
remove todo for 2828

### DIFF
--- a/cmd/ebrelayer/txs/registry_test.go
+++ b/cmd/ebrelayer/txs/registry_test.go
@@ -1,7 +1,0 @@
-package txs
-
-import "testing"
-
-// TODO: Implement test once current Truffle deployment is refactored (test requires a deployed smart contract)
-func TestGetAddressFromBridgeRegistry(t *testing.T) {
-}


### PR DESCRIPTION
there are lots of integration tests to verify registry contract. not very necessary to do it in unit test