### PR TITLE
Fix: margin open pool accounting

### DIFF
--- a/x/margin/keeper/keeper.go
+++ b/x/margin/keeper/keeper.go
@@ -307,10 +307,10 @@ func (k Keeper) Borrow(ctx sdk.Context, collateralAsset string, collateralAmount
 	nativeAsset := types.GetSettlementAsset()
 
 	if strings.EqualFold(mtp.CollateralAsset, nativeAsset) { // collateral is native
-		pool.NativeAssetBalance = pool.NativeAssetBalance.Add(mtp.CollateralAmount)
+		pool.NativeAssetBalance = pool.NativeAssetBalance.Sub(collateralAmount.Mul(leverage))
 		pool.NativeLiabilities = pool.NativeLiabilities.Add(mtp.LiabilitiesP)
 	} else { // collateral is external
-		pool.ExternalAssetBalance = pool.ExternalAssetBalance.Add(mtp.CollateralAmount)
+		pool.ExternalAssetBalance = pool.ExternalAssetBalance.Sub(collateralAmount.Mul(leverage))
 		pool.ExternalLiabilities = pool.ExternalLiabilities.Add(mtp.LiabilitiesP)
 	}
 	err = k.ClpKeeper().SetPool(ctx, pool)


### PR DESCRIPTION
Update to mtp open accounting in pool balances per @Rubz2021 PR here: https://github.com/Sifchain/margin_trading_cadCAD/pull/159/files#

changes to s_swap_X_A