### PR TITLE
Fix Protocol Automatic Force Close

### DIFF
--- a/x/margin/keeper/abci.go
+++ b/x/margin/keeper/abci.go
@@ -20,15 +20,14 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) {
 					continue // ?
 				}
 				pool.InterestRate = rate
+				_ = k.clpKeeper.SetPool(ctx, pool)
+				_ = k.UpdatePoolHealth(ctx, pool)
 				//mtps := k.GetMTPsForPool(ctx, pool) // TODO define
 				mtps := k.GetMTPsForCustodyAsset(ctx, pool.ExternalAsset.Symbol)
 				ctx.Logger().Info("Number of MTPs", "mtps", len(mtps))
 				for _, mtp := range mtps {
 					BeginBlockerProcessMTP(ctx, k, mtp, pool)
 				}
-
-				_ = k.UpdatePoolHealth(ctx, pool)
-				_ = k.clpKeeper.SetPool(ctx, pool)
 			}
 		}
 


### PR DESCRIPTION
abci.go was overwriting pool changes made by automatic force close. this was causing the close accounting issues that we were seeing. I moved the set pool to before the mtp close checks and things are working.

this issue was only present for the automated force close, not the normal close and force close transactions.