### PR TITLE
Fix bug in GetCmdAssets

### DIFF
--- a/x/clp/client/cli/query.go
+++ b/x/clp/client/cli/query.go
@@ -120,7 +120,7 @@ func GetCmdAssets(queryRoute string) *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
-			lpAddress := args[1]
+			lpAddress := args[0]
 
 			assetReq := types.AssetListReq{
 				LpAddress: lpAddress,


### PR DESCRIPTION
In this PR:

Resolves https://app.zenhub.com/workspaces/current-sprint---engineering-615a2e9fe2abd5001befc7f9/issues/sifchain/sifnode/2899
Fix is already in place in develop. Cherry-picked fix commit 