### PR TITLE
Add make smart contract as pre-step for build-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ install: go.sum ${smart_contract_file} .proto-gen
 install-bin: go.sum
 	go install ${BUILD_FLAGS} ${BINARIES}
 
+install-smart-contracts:
+	make -C smart-contracts install
+
 build-sifd: go.sum
 	go build  ${BUILD_FLAGS} ./cmd/sifnoded
 
@@ -82,7 +85,7 @@ feature-tests:
 run:
 	go run ./cmd/sifnoded start
 
-build-image:
+build-image: install-smart-contracts
 	docker build -t sifchain/$(BINARY):$(IMAGE_TAG) -f ./cmd/$(BINARY)/Dockerfile .
 
 run-image: build-image


### PR DESCRIPTION
In this PR:

Update make's build-image to run `smart-contracts` make install as prerequisite

This is needed because the build pipeline runs make build-image directly. 