### PR TITLE
add new argument maxMessagesInSifnodeTransaction 

### DIFF
--- a/cmd/ebrelayer/relayer/ethereum.go
+++ b/cmd/ebrelayer/relayer/ethereum.go
@@ -47,16 +47,17 @@ const (
 
 // EthereumSub is an Ethereum listener that can relay txs to Cosmos and Ethereum
 type EthereumSub struct {
-	EthProvider             string
-	TmProvider              string
-	RegistryContractAddress common.Address
-	ValidatorName           string
-	ValidatorAddress        sdk.ValAddress
-	NetworkDescriptor       oracletypes.NetworkDescriptor
-	CliCtx                  client.Context
-	PrivateKey              *ecdsa.PrivateKey
-	SugaredLogger           *zap.SugaredLogger
-	SifnodeGrpc             string
+	EthProvider                     string
+	TmProvider                      string
+	RegistryContractAddress         common.Address
+	ValidatorName                   string
+	ValidatorAddress                sdk.ValAddress
+	NetworkDescriptor               oracletypes.NetworkDescriptor
+	CliCtx                          client.Context
+	PrivateKey                      *ecdsa.PrivateKey
+	SugaredLogger                   *zap.SugaredLogger
+	SifnodeGrpc                     string
+	maxMessagesInSifnodeTransaction int
 }
 
 // NewKeybase create a new keybase instance
@@ -81,18 +82,20 @@ func NewEthereumSub(
 	registryContractAddress common.Address,
 	sugaredLogger *zap.SugaredLogger,
 	sifnodeGrpc string,
+	maxMessagesInSifnodeTransaction int,
 ) EthereumSub {
 
 	return EthereumSub{
-		EthProvider:             ethProvider,
-		TmProvider:              nodeURL,
-		NetworkDescriptor:       networkDescriptor,
-		RegistryContractAddress: registryContractAddress,
-		ValidatorName:           validatorMoniker,
-		ValidatorAddress:        nil,
-		CliCtx:                  cliCtx,
-		SugaredLogger:           sugaredLogger,
-		SifnodeGrpc:             sifnodeGrpc,
+		EthProvider:                     ethProvider,
+		TmProvider:                      nodeURL,
+		NetworkDescriptor:               networkDescriptor,
+		RegistryContractAddress:         registryContractAddress,
+		ValidatorName:                   validatorMoniker,
+		ValidatorAddress:                nil,
+		CliCtx:                          cliCtx,
+		SugaredLogger:                   sugaredLogger,
+		SifnodeGrpc:                     sifnodeGrpc,
+		maxMessagesInSifnodeTransaction: maxMessagesInSifnodeTransaction,
 	}
 }
 
@@ -466,7 +469,7 @@ func (sub EthereumSub) handleEthereumEvent(txFactory tx.Factory,
 		return lockBurnNonce, nil
 	}
 
-	return lockBurnNonce, txs.RelayToCosmos(txFactory, ethBridgeClaims, sub.CliCtx, sub.SugaredLogger)
+	return lockBurnNonce, txs.RelayToCosmos(txFactory, ethBridgeClaims, sub.CliCtx, sub.maxMessagesInSifnodeTransaction, sub.SugaredLogger)
 }
 
 // GetLockBurnSequenceFromCosmos via rpc

--- a/cmd/ebrelayer/txs/relayToCosmos.go
+++ b/cmd/ebrelayer/txs/relayToCosmos.go
@@ -12,15 +12,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-const MessagesInBatch = 5
-
 var (
 	errorMessageKey = "errorMessage"
 )
 
 // RelayToCosmos applies validator's signature to an EthBridgeClaim message containing
 // information about an event on the Ethereum blockchain before relaying to the Bridge
-func RelayToCosmos(factory tx.Factory, claims []*ethbridge.EthBridgeClaim, cliCtx client.Context, sugaredLogger *zap.SugaredLogger) error {
+func RelayToCosmos(factory tx.Factory, claims []*ethbridge.EthBridgeClaim, cliCtx client.Context, maxMessagesInSifnodeTransaction int, sugaredLogger *zap.SugaredLogger) error {
 	var messages []sdk.Msg
 
 	sugaredLogger.Infow(
@@ -44,7 +42,7 @@ func RelayToCosmos(factory tx.Factory, claims []*ethbridge.EthBridgeClaim, cliCt
 		} else {
 			messages = append(messages, &msg)
 			// to avoid too many data in single transaction, send out by batch
-			if len(messages) == MessagesInBatch {
+			if len(messages) == maxMessagesInSifnodeTransaction {
 				err = SendMessagesToCosmos(factory, cliCtx, messages, sugaredLogger)
 				if err != nil {
 					return err


### PR DESCRIPTION
In load testing, the TPS from Ethereum to Sifnode just 1. add new argument maxMessagesInSifnodeTransaction in ebrelayer, then relayer can put more messages in a single transaction.