### PR TITLE
Prevent use of yarn for smart contracts

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -96,5 +96,8 @@
   "dependencies": {
     "concurrently": "^6.2.0",
     "truffle": "^5.4.7"
+  },
+  "engines": {
+    "yarn": "999999999"
   }
 }


### PR DESCRIPTION
yarn doesn't work - it looks like it works, but it ends up breaking in subtle ways.