### PR TITLE
Bugfix/3151/missing blocklist check

### DIFF
--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -119,6 +119,8 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim *types.EthBridgeCl
 }
 
 // ProcessBurn processes the burn of bridged coins from the given sender
+//
+// Returns ProphecyID in byte slice
 func (k Keeper) ProcessBurn(ctx sdk.Context,
 	cosmosSender sdk.AccAddress,
 	senderSequence uint64,
@@ -129,6 +131,11 @@ func (k Keeper) ProcessBurn(ctx sdk.Context,
 
 	logger := k.Logger(ctx)
 	var coins sdk.Coins
+
+	if k.IsBlacklisted(ctx, msg.EthereumReceiver) {
+		return []byte{}, types.ErrBlacklistedAddress
+	}
+
 	networkIdentity := oracletypes.NewNetworkIdentity(msg.NetworkDescriptor)
 	crossChainFeeConfig, err := k.oracleKeeper.GetCrossChainFeeConfig(ctx, networkIdentity)
 
@@ -205,6 +212,11 @@ func (k Keeper) ProcessLock(ctx sdk.Context,
 
 	logger := k.Logger(ctx)
 	var coins sdk.Coins
+
+	if k.IsBlacklisted(ctx, msg.EthereumReceiver) {
+		return []byte{}, types.ErrBlacklistedAddress
+	}
+
 	networkIdentity := oracletypes.NewNetworkIdentity(msg.NetworkDescriptor)
 	crossChainFeeConfig, err := k.oracleKeeper.GetCrossChainFeeConfig(ctx, networkIdentity)
 

--- a/x/ethbridge/test/test_helpers.go
+++ b/x/ethbridge/test/test_helpers.go
@@ -94,6 +94,8 @@ func CreateTestKeepers(t *testing.T, consensusNeeded float64, validatorAmounts [
 	ms.MountStoreWithDB(keyOracle, sdk.StoreTypeIAVL, db)
 	ms.MountStoreWithDB(keyEthBridge, sdk.StoreTypeIAVL, db)
 	ms.MountStoreWithDB(keyTokenRegistry, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(adminKey, sdk.StoreTypeIAVL, db)
+
 	err := ms.LoadLatestVersion()
 	require.NoError(t, err)
 	ctx := sdk.NewContext(ms, tmproto.Header{ChainID: "foochainid"}, false, nil)

--- a/x/ethbridge/types/errors.go
+++ b/x/ethbridge/types/errors.go
@@ -13,4 +13,6 @@ var (
 	ErrInvalidEthereumChainID = sdkerrors.Register(ModuleName, 6, "invalid ethereum chain id")
 	ErrInvalidAmount          = sdkerrors.Register(ModuleName, 7, "amount must be a valid integer > 0")
 	ErrInvalidSymbol          = sdkerrors.Register(ModuleName, 8, "symbol must be 1 character or more")
+	// Set as 11 because 9 and 10 are present on master branch
+	ErrBlacklistedAddress = sdkerrors.Register(ModuleName, 11, "Ethereum Address is in blocklist, cannot execute tx")
 )


### PR DESCRIPTION
In this PR:

- Added blacklist checking behaviour for ProcessLock and ProcessBurn. This was in master but was dropped when we merge into future/peggy2.
- Added unit test to encapsulate behaviour