### PR TITLE
fix: add liq reward bucker sender address

### DIFF
--- a/x/clp/keeper/add_liquidity_to_rewards_bucket.go
+++ b/x/clp/keeper/add_liquidity_to_rewards_bucket.go
@@ -6,16 +6,20 @@ import (
 )
 
 func (k Keeper) AddLiquidityToRewardsBucket(ctx sdk.Context, signer string, amounts sdk.Coins) (sdk.Coins, error) {
+	addr, err := sdk.AccAddressFromBech32(signer)
+	if err != nil {
+		return nil, err
+	}
+
 	// check that the sender has all the coins in the wallet
 	for _, coin := range amounts {
-		if !k.bankKeeper.HasBalance(ctx, sdk.AccAddress(signer), coin) {
+		if !k.bankKeeper.HasBalance(ctx, addr, coin) {
 			return nil, types.ErrBalanceNotAvailable
 		}
 	}
 
 	// send from user to module
-	err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, sdk.AccAddress(signer), types.ModuleName, amounts)
-	if err != nil {
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, addr, types.ModuleName, amounts); err != nil {
 		return nil, err
 	}
 

--- a/x/clp/keeper/add_liquidity_to_rewards_bucket_test.go
+++ b/x/clp/keeper/add_liquidity_to_rewards_bucket_test.go
@@ -12,23 +12,26 @@ import (
 func TestAddLiquidityToRewardsBucket(t *testing.T) {
 	keeper, ctx, bankKeeper := keepertest.ClpKeeper(t)
 
-	signer := "sif1addliquidityaddress"
+	signer := "sif1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3sxxeku"
 	amount := sdk.NewCoins(sdk.NewInt64Coin("atom", 100))
 	msg := types.NewMsgAddLiquidityToRewardsBucketRequest(signer, amount)
 
+	addr, err := sdk.AccAddressFromBech32(signer)
+	require.NoError(t, err)
+
 	// Mock expectations
 	bankKeeper.EXPECT().
-		HasBalance(ctx, sdk.AccAddress(msg.Signer), msg.Amount[0]).
+		HasBalance(ctx, addr, msg.Amount[0]).
 		Return(true).
 		Times(1)
 
 	bankKeeper.EXPECT().
-		SendCoinsFromAccountToModule(ctx, sdk.AccAddress(msg.Signer), types.ModuleName, sdk.NewCoins(msg.Amount...)).
+		SendCoinsFromAccountToModule(ctx, addr, types.ModuleName, sdk.NewCoins(msg.Amount...)).
 		Return(nil).
 		Times(1)
 
 	// Call the method
-	_, err := keeper.AddLiquidityToRewardsBucket(ctx, msg.Signer, msg.Amount)
+	_, err = keeper.AddLiquidityToRewardsBucket(ctx, msg.Signer, msg.Amount)
 	require.NoError(t, err)
 
 	// check if rewards bucket is created
@@ -42,18 +45,21 @@ func TestAddLiquidityToRewardsBucket(t *testing.T) {
 func TestAddLiquidityToRewardsBucket_BalanceNotAvailable(t *testing.T) {
 	keeper, ctx, bankKeeper := keepertest.ClpKeeper(t)
 
-	signer := "sif1addliquidityaddress"
+	signer := "sif1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3sxxeku"
 	amount := sdk.NewCoins(sdk.NewInt64Coin("atom", 100))
 	msg := types.NewMsgAddLiquidityToRewardsBucketRequest(signer, amount)
 
+	addr, err := sdk.AccAddressFromBech32(signer)
+	require.NoError(t, err)
+
 	// Mock expectations for HasBalance to return false
 	bankKeeper.EXPECT().
-		HasBalance(ctx, sdk.AccAddress(msg.Signer), msg.Amount[0]).
+		HasBalance(ctx, addr, msg.Amount[0]).
 		Return(false).
 		Times(1)
 
 	// Call the method and expect an error
-	_, err := keeper.AddLiquidityToRewardsBucket(ctx, msg.Signer, msg.Amount)
+	_, err = keeper.AddLiquidityToRewardsBucket(ctx, msg.Signer, msg.Amount)
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrBalanceNotAvailable)
 
@@ -66,31 +72,34 @@ func TestAddLiquidityToRewardsBucket_BalanceNotAvailable(t *testing.T) {
 func TestAddLiquidityToRewardsBucket_MultipleCoins(t *testing.T) {
 	keeper, ctx, bankKeeper := keepertest.ClpKeeper(t)
 
-	signer := "sif1addliquidityaddress"
+	signer := "sif1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3sxxeku"
 	amount := sdk.NewCoins(
 		sdk.NewInt64Coin("atom", 100),
 		sdk.NewInt64Coin("rowan", 100),
 	)
 	msg := types.NewMsgAddLiquidityToRewardsBucketRequest(signer, amount)
 
+	addr, err := sdk.AccAddressFromBech32(signer)
+	require.NoError(t, err)
+
 	// Mock expectations
 	bankKeeper.EXPECT().
-		HasBalance(ctx, sdk.AccAddress(msg.Signer), msg.Amount[0]).
+		HasBalance(ctx, addr, msg.Amount[0]).
 		Return(true).
 		Times(1)
 
 	bankKeeper.EXPECT().
-		HasBalance(ctx, sdk.AccAddress(msg.Signer), msg.Amount[1]).
+		HasBalance(ctx, addr, msg.Amount[1]).
 		Return(true).
 		Times(1)
 
 	bankKeeper.EXPECT().
-		SendCoinsFromAccountToModule(ctx, sdk.AccAddress(msg.Signer), types.ModuleName, sdk.NewCoins(msg.Amount...)).
+		SendCoinsFromAccountToModule(ctx, addr, types.ModuleName, sdk.NewCoins(msg.Amount...)).
 		Return(nil).
 		Times(1)
 
 	// Call the method
-	_, err := keeper.AddLiquidityToRewardsBucket(ctx, msg.Signer, msg.Amount)
+	_, err = keeper.AddLiquidityToRewardsBucket(ctx, msg.Signer, msg.Amount)
 	require.NoError(t, err)
 
 	// check if rewards bucket is created

--- a/x/clp/keeper/migrations.go
+++ b/x/clp/keeper/migrations.go
@@ -88,9 +88,6 @@ func (m Migrator) MigrateToVer4(ctx sdk.Context) error {
 }
 
 func (m Migrator) MigrateToVer5(ctx sdk.Context) error {
-	// set rewards bucket
-	m.keeper.SetRewardsBucket(ctx, types.RewardsBucket{})
-
 	// set rewards params
 	m.keeper.SetRewardParams(ctx, types.GetDefaultRewardParams())
 


### PR DESCRIPTION
* Fix signer address parser logic in add liquidity to rewards buckets function
* Fix test cases
* Remove unnecessary entry adding in migration function